### PR TITLE
Update PageBuilder version in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
   - if [[ "$BOARD" =~ "esp32:esp32:" ]]; then
       arduino --install-boards esp32:esp32;
     fi
-  - arduino --install-library PubSubClient,PageBuilder:1.1.0
+  - arduino --install-library PubSubClient,PageBuilder:1.2.3
   - buildExampleSketch() { arduino --verbose-build --verify --board $BOARD $PWD/examples/$1/$1.ino; }
 install:
   - mkdir -p ~/Arduino/libraries


### PR DESCRIPTION
The /Hieromon/PageBuilder repository's 1.1.0 appears to have been deleted and the only tag now is 1.2.3. This resulted in failure of the Travis CI build:
https://travis-ci.org/per1234/AutoConnect/jobs/474724488#L731
```
Selected library is not available
The command "arduino --install-library PubSubClient,PageBuilder:1.1.0" failed and exited with 1 during .
```
Note that there is a separate issue that still causes the Travis CI build to fail even after this change:
https://travis-ci.org/per1234/AutoConnect/jobs/474727745#L751
```
Error: CpuFrequency: Invalid option for board "nodemcuv2"
```
This is caused by a breaking change in the ESP8266 core (https://github.com/esp8266/Arduino/issues/5572). There is some talk of possibly reverting that change so I don't know whether you want to hold off on updating the ESP8266 FQBN until that's settled. The fix is simply to change `CpuFrequency` to `xtal`, after which the Travis CI build will pass. If you would like me to also fix that error, I'm happy to do so.