### PR TITLE
Add support to extend pages through virtual _setupPage method

### DIFF
--- a/src/AutoConnect.h
+++ b/src/AutoConnect.h
@@ -240,7 +240,7 @@ class AutoConnect {
   bool  _loadAvailCredential();
   void  _stopPortal();
   bool  _classifyHandle(HTTPMethod mothod, String uri);
-  PageElement*  _setupPage(String uri);
+  virtual PageElement*  _setupPage(String uri);
 
   /** Request handlers implemented by Page Builder */
   String  _induceConnect(PageArgument& args);
@@ -268,7 +268,7 @@ class AutoConnect {
 
   PageBuilder*  _responsePage;
   PageElement*  _currentPageElement;
-  
+
    /** configurations */
   AutoConnectConfig     _apConfig;
   struct station_config _credential;


### PR DESCRIPTION
I really like the way it's structured, so for my particular case it comes very handy to be able to extend the number of pages from a class that inherits from `AutoConnect` class.

e.g.
```
PageElement* WebConfig::_setupPage(String uri) {
    if (uri == String("/")) {
        return getHomePageElement();
    } else if (uri == String("/param/0002")) {
        PageElement* e = new PageElement();
        e->setMold("{{PLAIN}}");
        e->addToken(PSTR("PLAIN"), std::bind(&WebConfig::_token_PLAIN, this, std::placeholders::_1));
        return e;
    }

    return AutoConnect::_setupPage(uri);
}
```