### PR TITLE
Add <br> after ACSelect element

### DIFF
--- a/src/AutoConnectElementBasisImpl.h
+++ b/src/AutoConnectElementBasisImpl.h
@@ -261,6 +261,7 @@ const String AutoConnectSelectBasis::toHTML(void) const {
       html += ">" + option + String(F("</option>"));
     }
     html += String(F("</select>"));
+    html += String(F("<br>"));
   }
   return html;
 }


### PR DESCRIPTION
After an ACSelect element teh <br> is missing.