### PR TITLE
Fixed bug fix in AutoConnectCredential when offset is >256

### DIFF
--- a/src/AutoConnectCredential.cpp
+++ b/src/AutoConnectCredential.cpp
@@ -210,10 +210,10 @@ bool AutoConnectCredential::save(const struct station_config* config) {
   }
 
   // Seek insertion point, evaluate capacity to insert the new entry.
-  uint8_t eSize = strlen((const char*)config->ssid) + strlen((const char*)config->password) + sizeof(station_config::bssid) + 2;
+  uint16_t eSize = strlen((const char*)config->ssid) + strlen((const char*)config->password) + sizeof(station_config::bssid) + 2;
   for (_dp = AC_HEADERSIZE; _dp < _containSize + AC_HEADERSIZE; _dp++) {
     if (EEPROM.read(_dp) == 0xff) {
-      uint8_t fp = _dp;
+      uint16_t fp = _dp;
       while (EEPROM.read(++_dp) == 0xff) {}
       if (_dp - fp >= eSize) {
         _dp = fp;


### PR DESCRIPTION
AutoConnectCredential uses uint8_t fp = _dp; to store off position, and later reassigns it back to _dp. This works only when the value in _dp can fit in a uint8_t. This fix changes the type of fp and eSize to uint16_t to allow proper function with offsets greater than 256, 

Tested with ESP8266/NodeMCU, using offset 1024. 