### PR TITLE
Initialize member correctly: May lead to instant disconnect in some situations.

### DIFF
--- a/src/AutoConnect.cpp
+++ b/src/AutoConnect.cpp
@@ -48,6 +48,7 @@ AutoConnect::AutoConnect(WebServerClass& webServer) {
 void AutoConnect::_initialize(void) {
   _rfConnect = false;
   _rfReset = false;
+  _rfDisconnect = false;
   _responsePage = nullptr;
   _currentPageElement = nullptr;
   _menuTitle = _apConfig.title;


### PR DESCRIPTION
Initialize state member to ensure correct behaviour also after reset.

refs #139