### PR TITLE
use booturi for new connection and for menu

### DIFF
--- a/src/AutoConnect.cpp
+++ b/src/AutoConnect.cpp
@@ -311,6 +311,16 @@ bool AutoConnect::_configSTA(const IPAddress& ip, const IPAddress& gateway, cons
   return rc;
 }
 
+String AutoConnect::_getBootUri()
+{
+  if (_apConfig.bootUri == AC_ONBOOTURI_ROOT)
+    return String(AUTOCONNECT_URI);
+  else if (_apConfig.bootUri == AC_ONBOOTURI_HOME)
+    return _apConfig.homeUri.length() > 0 ? _apConfig.homeUri : String("/");
+  else
+    return _emptyString;
+}
+
 /**
  *  Obtains the currently established AP connection to determine if the
  *  station configuration needs to run before the first WiFi.begin.
@@ -675,7 +685,7 @@ bool AutoConnect::_captivePortal(void) {
   String  hostHeader = _webServer->hostHeader();
   if (!_isIP(hostHeader) && (hostHeader != WiFi.localIP().toString()) && (!hostHeader.endsWith(F(".local")))) {
     AC_DBG("Detected application, %s, %s\n", hostHeader.c_str(), WiFi.localIP().toString().c_str());
-    String location = String(F("http://")) + _webServer->client().localIP().toString() + String(AUTOCONNECT_URI);
+    String location = String(F("http://")) + _webServer->client().localIP().toString() + _getBootUri();
     _webServer->sendHeader(String(F("Location")), location, true);
     _webServer->send(302, String(F("text/plain")), _emptyString);
     _webServer->client().flush();

--- a/src/AutoConnect.h
+++ b/src/AutoConnect.h
@@ -224,6 +224,7 @@ class AutoConnect {
   } AC_STARECONNECT_t;
   bool  _config(void);
   bool  _configSTA(const IPAddress& ip, const IPAddress& gateway, const IPAddress& netmask, const IPAddress& dns1, const IPAddress& dns2);
+  String _getBootUri();
   bool  _getConfigSTA(station_config_t* config);
   void  _startWebServer(void);
   void  _startDNSServer(void);

--- a/src/AutoConnectPage.cpp
+++ b/src/AutoConnectPage.cpp
@@ -550,7 +550,7 @@ const char  AutoConnect::_ELM_MENU_PRE[] PROGMEM = {
     "<div class=\"lb-menu lb-menu-right lb-menu-material\">"
       "<ul class=\"lb-navigation\">"
         "<li class=\"lb-header\">"
-          "<a href=\"" AUTOCONNECT_URI "\" class=\"lb-brand\">MENU_TITLE</a>"
+          "<a href=\"BOOT_URI\" class=\"lb-brand\">MENU_TITLE</a>"
           "<label class=\"lb-burger lb-burger-dblspin\" id=\"lb-burger\" for=\"lb-cb\"><span></span></label>"
         "</li>"
         "<li class=\"lb-item\"><a href=\"" AUTOCONNECT_URI_CONFIG "\">" AUTOCONNECT_MENULABEL_CONFIGNEW "</a></li>"
@@ -972,6 +972,7 @@ String AutoConnect::_token_HEAD(PageArgument& args) {
 
 String AutoConnect::_token_MENU_PRE(PageArgument& args) {
   String  currentMenu = FPSTR(_ELM_MENU_PRE);
+  currentMenu.replace(String(F("BOOT_URI")), _getBootUri());
   currentMenu.replace(String(F("MENU_TITLE")), _menuTitle);
   currentMenu.replace(String(F("{{CUR_SSID}}")), _token_ESTAB_SSID(args));
   return currentMenu;
@@ -1340,12 +1341,7 @@ String AutoConnect::_token_UPTIME(PageArgument& args) {
 
 String AutoConnect::_token_BOOTURI(PageArgument& args) {
   AC_UNUSED(args);
-  if (_apConfig.bootUri == AC_ONBOOTURI_ROOT)
-    return String(AUTOCONNECT_URI);
-  else if (_apConfig.bootUri == AC_ONBOOTURI_HOME)
-    return _apConfig.homeUri.length() > 0 ? _apConfig.homeUri : String("/");
-  else
-    return _emptyString;
+  return _getBootUri();
 }
 
 String AutoConnect::_token_CURRENT_SSID(PageArgument& args) {


### PR DESCRIPTION
AutoConnect was displaying device statistics on every new connection.
Now it should be able to display booturi, so user is able to use
his page as boot page. This booturi is used as link for
title of the menu too.