### PR TITLE
Fix setElementValue for checkbox.

### DIFF
--- a/src/AutoConnectAux.cpp
+++ b/src/AutoConnectAux.cpp
@@ -188,9 +188,13 @@ bool AutoConnectAux::setElementValue(const String& name, const String value) {
     }
     else {
       if (elm->typeOf() == AC_Checkbox) {
+        AutoConnectCheckbox* elmCheckbox = reinterpret_cast<AutoConnectCheckbox*>(elm);
         if (value == "checked") {
-          AutoConnectCheckbox* elmCheckbox = reinterpret_cast<AutoConnectCheckbox*>(elm);
           elmCheckbox->checked = true;
+        }
+        else
+        {
+          elmCheckbox->checked = false;
         }
       }
       else if (elm->typeOf() == AC_Radio) {


### PR DESCRIPTION
This is fixing the issue, when setElementValue is called on checkbox
element, which is already checked. Now it is possible to uncheck this
element.