### PR TITLE
Add files via upload (Automatic SSID selection depending on RSSI strength)

### DIFF
--- a/src/AutoConnect.h
+++ b/src/AutoConnect.h
@@ -58,6 +58,10 @@ class AutoConnectConfig {
    *  assigned from macro. Password is same as above too.
    */
   AutoConnectConfig() :
+#ifdef INC_RSSI_USE_SUP  //!!!
+    conMinRSSI(AUTOCONNECT_CON_MIN_RSSI),
+    conFindMaxRSSI(AUTOCONNECT_CON_FIND_MAX_RSSI),
+#endif    
     apip(AUTOCONNECT_AP_IP),
     gateway(AUTOCONNECT_AP_GW),
     netmask(AUTOCONNECT_AP_NM),
@@ -90,6 +94,10 @@ class AutoConnectConfig {
    *  Configure by SSID for the captive portal access point and password.
    */
   AutoConnectConfig(const char* ap, const char* password, const unsigned long portalTimeout = 0, const uint8_t channel = AUTOCONNECT_AP_CH) :
+#ifdef INC_RSSI_USE_SUP  //!!!
+    conMinRSSI(AUTOCONNECT_CON_MIN_RSSI),
+    conFindMaxRSSI(AUTOCONNECT_CON_FIND_MAX_RSSI),
+#endif    
     apip(AUTOCONNECT_AP_IP),
     gateway(AUTOCONNECT_AP_GW),
     netmask(AUTOCONNECT_AP_NM),
@@ -122,6 +130,10 @@ class AutoConnectConfig {
   ~AutoConnectConfig() {}
 
   AutoConnectConfig& operator=(const AutoConnectConfig& o) {
+#ifdef INC_RSSI_USE_SUP  //!!!
+    conMinRSSI=o.conMinRSSI;
+    conFindMaxRSSI=o.conFindMaxRSSI;
+#endif    
     apip = o.apip;
     gateway = o.gateway;
     netmask = o.netmask;
@@ -153,6 +165,11 @@ class AutoConnectConfig {
     return *this;
   }
 
+
+#ifdef INC_RSSI_USE_SUP   //!!!
+  int       conMinRSSI;          /**< Minimum AP signal strength accepted for connection */
+  bool      conFindMaxRSSI;      /**< Find stored AP with highest signal strength for connection */
+#endif
   IPAddress apip;               /**< SoftAP IP address */
   IPAddress gateway;            /**< SoftAP gateway address */
   IPAddress netmask;            /**< SoftAP subnet mask */

--- a/src/AutoConnectDefs.h
+++ b/src/AutoConnectDefs.h
@@ -10,6 +10,19 @@
 #ifndef _AUTOCONNECTDEFS_H_
 #define _AUTOCONNECTDEFS_H_
 
+//!!!
+#define INC_RSSI_USE_SUP   1
+
+#ifdef INC_RSSI_USE_SUP   //!!!
+#ifndef AUTOCONNECT_CON_MIN_RSSI
+#define AUTOCONNECT_CON_MIN_RSSI     -100       // no limit
+#endif
+
+#ifndef AUTOCONNECT_CON_FIND_MAX_RSSI
+#define AUTOCONNECT_CON_FIND_MAX_RSSI  false       // use first available
+#endif
+#endif
+
 // Uncomment the following AC_DEBUG to enable debug output.
 //#define AC_DEBUG
 
@@ -24,6 +37,7 @@
 #define AC_DBG(...)
 #define AC_DBG_DUMB(...)
 #endif // !AC_DEBUG
+
 
 // Indicator to specify that AutoConnectAux handles elements with JSON.
 // Comment out the AUTOCONNECT_USE_JSON macro to detach the ArduinoJson.


### PR DESCRIPTION

AutoConnect is a great library but I have need to move around and noticed it only reconnected to last connected AP even when the signal was weak and other stored AP's with much stronger signal were available.  It was inconvenient to have to manually switch AP after moving device as good Wifi signal is necessary for my needs.  So, I added code to AutoConnect for configurable settings of:

* Minimum RSSI setting for connection (conMinRSSI)
* Option to connect to stored AP with strongest RSSI (conFindMaxRSSI)

I think the changes could be useful for others using AutoConnect.
