### PR TITLE
move AC_LABELS directive to header file

### DIFF
--- a/src/AutoConnectLabels.h
+++ b/src/AutoConnectLabels.h
@@ -286,4 +286,31 @@
 #define AUTOCONNECT_MENUCOLOR_ACTIVE      "#37474f"
 // #define AUTOCONNECT_MENUCOLOR_ACTIVE      "#808080"
 #endif
+
+/**< Override the hardcoded strings contained in the AutoConnect pages.    */
+/**< e.g. for PlatformIO, you can add your environment in platformio.ini   */
+/**< along with AC_LABLES macro which specifies the user-defined label     */
+/**< constants as follows:                                                 */
+/**<                                                                       */
+/**< build_flags =                                                         */
+/**<   -DAC_LABELS='"${PROJECT_SRC_DIR}/mylabels.h"'                       */
+/**<                                                                       */
+/**< And places mylabels.h, it needs a structure of the define directive   */
+/**< provided per label string definition for the change your wants.       */
+/**<                                                                       */
+/**< #ifdef [ID YOU WANT TO CHANGE]                                        */
+/**< #undef [ID YOU WANT TO CHANGE]                                        */
+/**< #define [ID YOU WANT TO CHANGE] "NEW_STRING_FOR_THISONE"              */
+/**< #endif                                                                */
+/**<                                                                       */
+/**< example:
+#ifdef AUTOCONNECT_MENULABEL_CONFIGNEW
+#undef AUTOCONNECT_MENULABEL_CONFIGNEW
+#define AUTOCONNECT_MENULABEL_CONFIGNEW   "NEW_STRING_FOR_THISONE"
+#endif
+*/
+#ifdef AC_LABELS
+#include AC_LABELS
+#endif
+
 #endif

--- a/src/AutoConnectPage.cpp
+++ b/src/AutoConnectPage.cpp
@@ -19,32 +19,6 @@ extern "C" {
 #endif
 #include "AutoConnect.h"
 #include "AutoConnectPage.h"
-/**< Override the hardcoded strings contained in the AutoConnect pages.    */
-/**< e.g. for PlatformIO, you can add your environment in platformio.ini   */
-/**< along with AC_LABLES macro which specifies the user-defined label     */
-/**< constants as follows:                                                 */
-/**<                                                                       */
-/**< build_flags =                                                         */
-/**<   -DAC_LABELS='"${PROJECT_SRC_DIR}/mylabels.h"'                       */
-/**<                                                                       */
-/**< And places mylabels.h, it needs a structure of the define directive   */
-/**< provided per label string definition for the change your wants.       */
-/**<                                                                       */
-/**< #ifdef [ID YOU WANT TO CHANGE]                                        */
-/**< #undef [ID YOU WANT TO CHANGE]                                        */
-/**< #define [ID YOU WANT TO CHANGE] "NEW_STRING_FOR_THISONE"              */
-/**< #endif                                                                */
-/**<                                                                       */
-/**< example:
-#ifdef AUTOCONNECT_MENULABEL_CONFIGNEW
-#undef AUTOCONNECT_MENULABEL_CONFIGNEW
-#define AUTOCONNECT_MENULABEL_CONFIGNEW   "NEW_STRING_FOR_THISONE"
-#endif
-*/
-#ifdef AC_LABELS
-#include  AC_LABELS
-#endif
-
 #include "AutoConnectCredential.h"
 
 /**< Basic CSS common to all pages */


### PR DESCRIPTION
Labels can be redefined, so the best place seems to be this one,
right after labels definition. In original place there was problem with
OTA translation.