### PR TITLE
Added preserveAPMode setting

### DIFF
--- a/src/AutoConnect.cpp
+++ b/src/AutoConnect.cpp
@@ -79,10 +79,19 @@ bool AutoConnect::begin(const char* ssid, const char* passphrase, unsigned long 
   // Overwrite for the current timeout value.
   _connectTimeout = timeout;
 
-  // Start WiFi connection with station mode.
-  WiFi.softAPdisconnect(true);
-  WiFi.mode(WIFI_STA);
-  delay(100);
+  if (_apConfig.preserveAPMode && !_apConfig.autoRise) {
+    // Captive portal will not be started on connection failure. Enable Station mode
+    // without disabling any current soft AP.
+    cs = WiFi.enableSTA(true);
+    AC_DBG(PSTR("Enable WIFI_STA: %s\n"), cs ? "Ok" : "Failed");
+  }
+  else {
+    // Start WiFi connection with station mode.
+    WiFi.softAPdisconnect(true);
+    cs = WiFi.mode(WIFI_STA);
+    delay(100);
+    AC_DBG(PSTR("Switch to WIFI_STA: %s\n"), cs ? "Ok" : "Failed");
+  }
 
   // Set host name
   if (_apConfig.hostName.length())

--- a/src/AutoConnect.h
+++ b/src/AutoConnect.h
@@ -105,6 +105,7 @@ class AutoConnectConfig {
     autoReconnect(false),
     immediateStart(false),
     retainPortal(false),
+    preserveAPMode(false),
     portalTimeout(AUTOCONNECT_CAPTIVEPORTAL_TIMEOUT),
     menuItems(AC_MENUITEM_CONFIGNEW | AC_MENUITEM_OPENSSIDS | AC_MENUITEM_DISCONNECT | AC_MENUITEM_RESET | AC_MENUITEM_UPDATE | AC_MENUITEM_HOME),
     ticker(false),
@@ -141,6 +142,7 @@ class AutoConnectConfig {
     autoReconnect(false),
     immediateStart(false),
     retainPortal(false),
+    preserveAPMode(false),
     portalTimeout(portalTimeout),
     menuItems(AC_MENUITEM_CONFIGNEW | AC_MENUITEM_OPENSSIDS | AC_MENUITEM_DISCONNECT | AC_MENUITEM_RESET | AC_MENUITEM_UPDATE | AC_MENUITEM_HOME),
     ticker(false),
@@ -177,6 +179,7 @@ class AutoConnectConfig {
     autoReconnect = o.autoReconnect;
     immediateStart = o.immediateStart;
     retainPortal = o.retainPortal;
+    preserveAPMode = o.preserveAPMode;
     portalTimeout = o.portalTimeout;
     menuItems = o.menuItems;
     ticker = o.ticker;
@@ -213,6 +216,7 @@ class AutoConnectConfig {
   bool      autoReconnect;      /**< Automatic reconnect with past SSID */
   bool      immediateStart;     /**< Skips WiFi.begin(), start portal immediately */
   bool      retainPortal;       /**< Even if the captive portal times out, it maintains the portal state. */
+  bool      preserveAPMode;     /**< Keep existing AP WiFi mode if captive portal won't be started. */
   unsigned long portalTimeout;  /**< Timeout value for stay in the captive portal */
   uint16_t  menuItems;          /**< A compound value of the menu items to be attached */
   bool      ticker;             /**< Drives LED flicker according to WiFi connection status. */


### PR DESCRIPTION
Hi Hieromon,

Here is the code change that allows me to successfully use ESP-Now in my sketch. I added a new configuration setting `preserveAPMode` that avoids any changes to the soft AP mode settings when AutoConnect.begin is called.

I limited the change so that it **only** applies in the case where the code is using AutoConnect.begin to attempt to connect to the WLAN but **will not** start the portal in the event of a failure (autoRise is false). This should avoid damaging any existing behaviour.

Thanks for considering this change.
resolves  Hieromon/AutoConnect#210