### PR TITLE
fix AutoConnectElementBasisImpl.h:124:18: error: no match for 'operat…

### DIFF
--- a/src/AutoConnectElementBasisImpl.h
+++ b/src/AutoConnectElementBasisImpl.h
@@ -121,7 +121,7 @@ bool AutoConnectFileBasis::attach(const ACFile_t store) {
   case AC_File_Extern:
     break;
   }
-  return _upload != false;
+  return _upload ? true : false;
 }
 
 /**


### PR DESCRIPTION
Fix compilation with gcc 8.2.0. #263 