### PR TITLE
update URI and refresh timeout

### DIFF
--- a/src/AutoConnectDefs.h
+++ b/src/AutoConnectDefs.h
@@ -50,7 +50,7 @@
 // Declaration to enable AutoConnectConfigAux.
 // AC_USE_CONFIGAUX must be enabled along with AUTOCONNECT_USE_JSON
 // to enable AutoConnectConfigAux.
-//#define AC_USE_CONFIGAUX 
+//#define AC_USE_CONFIGAUX
 #if defined(AC_USE_CONFIGAUX) && defined(AUTOCONNECT_USE_JSON)
 #define AUTOCONNECT_USE_CONFIGAUX
 #endif
@@ -220,7 +220,7 @@
 #define AUTOCONNECT_FLICKER_WIDTHAP   96
 #endif // !AUTOCONNECT_FLICKER_WIDTHAP
 // Flicker pulse width while WiFi is not connected (8bit resolution)
-#ifndef AUTOCONNECT_FLICKER_WIDTHDC 
+#ifndef AUTOCONNECT_FLICKER_WIDTHDC
 #define AUTOCONNECT_FLICKER_WIDTHDC   16
 #endif // !AUTOCONNECT_FLICKER_WIDTHDISCON
 // Ticker port
@@ -265,7 +265,7 @@
 
 // Interval time of progress status periodical inquiry [ms]
 #ifndef AUTOCONNECT_UPDATE_INTERVAL
-#define AUTOCONNECT_UPDATE_INTERVAL   400
+#define AUTOCONNECT_UPDATE_INTERVAL   1500
 #endif // !AUTOCONNECT_UPDATE_INTERVAL
 
 // Wait timer for rebooting after updated

--- a/src/AutoConnectUpdate.cpp
+++ b/src/AutoConnectUpdate.cpp
@@ -255,7 +255,11 @@ void AutoConnectUpdateAct::handleUpdate(void) {
  */
 AC_UPDATESTATUS_t AutoConnectUpdateAct::update(void) {
   // Start update
-  String  uriBin = uri + '/' + _binName;
+  String uriBin = '/' + _binName;
+  if (uri != String("."))
+  {
+    uriBin = uri + '/' + _binName;
+  }
   if (_binName.length()) {
     WiFiClient  wifiClient;
     AC_DBG("%s:%d/%s update in progress...", host.c_str(), port, uriBin.c_str());
@@ -304,7 +308,7 @@ AC_UPDATESTATUS_t AutoConnectUpdateAct::update(void) {
  * received AutoConnectAux.
  * @param  aux        An instantiated AutoConnectAux that will configure according to ACPage_t.
  * @param  page       Pre-defined ACPage_t
- * @param  elementNum Number of AutoConnectElements to configure.  
+ * @param  elementNum Number of AutoConnectElements to configure.
  */
 void AutoConnectUpdateAct::_buildAux(AutoConnectAux* aux, const AutoConnectAux::ACPage_t* page, const size_t elementNum) {
   for (size_t n = 0; n < elementNum; n++) {
@@ -574,7 +578,7 @@ void AutoConnectUpdateAct::_progress(void) {
   case HTTP_GET:
     switch (_status) {
     case UPDATE_PROGRESS:
-      payload = String(UPDATE_NOTIFY_PROGRESS) + ',' + String(_amount) + ':' + String(_binSize); 
+      payload = String(UPDATE_NOTIFY_PROGRESS) + ',' + String(_amount) + ':' + String(_binSize);
       httpCode = 200;
       break;
     case UPDATE_IDLE:


### PR DESCRIPTION
Hello! Thank you for your great work!
I found 2 issues on the update thru server.
1) If I try to download a bin from the root "." of the catalog the URL generated was wrong eg. http://hostname:port./firmware.bin. The dot must not be added, I tried to implement the update server on NodeJS and Express was complaining about that. 
2) The refresh interval for the update progress in the javascript code was 400ms, is too low, when I update Chrome get flooded of requests and the update fail. 1500ms is a more reasonable interval.
