### PR TITLE
show device uptime on status page

### DIFF
--- a/src/AutoConnectCore.hpp
+++ b/src/AutoConnectCore.hpp
@@ -120,6 +120,7 @@ class AutoConnectCore {
   String              _attachMenuItem(const AC_MENUITEM_t item);
   static uint32_t     _getChipId(void);
   static uint32_t     _getFlashChipRealSize(void);
+  static String       _getSystemUptime(void);
   static String       _toMACAddressString(const uint8_t mac[]);
   static unsigned int _toWiFiQuality(int32_t rssi);
   ConnectExit_ft      _onConnectExit;
@@ -216,6 +217,7 @@ class AutoConnectCore {
   String _token_ESTAB_SSID(PageArgument& args);
   String _token_FLASH_SIZE(PageArgument& args);
   String _token_FREE_HEAP(PageArgument& args);
+  String _token_SYSTEM_UPTIME(PageArgument &args);
   String _token_GATEWAY(PageArgument& args);
   String _token_HEAD(PageArgument& args);
   String _token_HIDDEN_COUNT(PageArgument& args);

--- a/src/AutoConnectLabels.h
+++ b/src/AutoConnectLabels.h
@@ -167,6 +167,11 @@
 #define AUTOCONNECT_PAGESTATS_FREEMEM "Free memory"
 #endif // !AUTOCONNECT_PAGESTATS_FREEMEM
 
+// Page statistics row: Systemuptime
+#ifndef AUTOCONNECT_PAGESTATS_SYSTEM_UPTIME
+#define AUTOCONNECT_PAGESTATS_SYSTEM_UPTIME "System uptime"
+#endif // !AUTOCONNECT_PAGESTATS_SYSTEM_UPTIME
+
 // Page title: AutoConnect config
 #ifndef AUTOCONNECT_PAGETITLE_CONFIG
 #define AUTOCONNECT_PAGETITLE_CONFIG "AutoConnect config"

--- a/src/AutoConnectPageImpl.hpp
+++ b/src/AutoConnectPageImpl.hpp
@@ -12,7 +12,8 @@
 
 #if defined(ARDUINO_ARCH_ESP8266)
 #include <ESP8266WiFi.h>
-extern "C" {
+extern "C"
+{
 #include <user_interface.h>
 }
 #elif defined(ARDUINO_ARCH_ESP32)
@@ -22,55 +23,55 @@ extern "C" {
 #endif
 
 /**< Basic CSS common to all pages */
-template<typename T>
+template <typename T>
 const char AutoConnectCore<T>::_CSS_BASE[] PROGMEM = {
-  "html{"
+    "html{"
     "font-family:Helvetica,Arial,sans-serif;"
     "font-size:16px;"
     "-ms-text-size-adjust:100%;"
     "-webkit-text-size-adjust:100%;"
     "-moz-osx-font-smoothing:grayscale;"
     "-webkit-font-smoothing:antialiased"
-  "}"
-  "body{"
+    "}"
+    "body{"
     "margin:0;"
     "padding:0"
-  "}"
-  ".base-panel{"
+    "}"
+    ".base-panel{"
     "margin:0 22px 0 22px"
-  "}"
-  ".base-panel * label :not(.bins){"
+    "}"
+    ".base-panel * label :not(.bins){"
     "display:inline-block;"
     "width:3.0em;"
     "text-align:right"
-  "}"
-  ".base-panel * .slist{"
+    "}"
+    ".base-panel * .slist{"
     "width:auto;"
     "font-size:0.9em;"
     "margin-left:10px;"
     "text-align:left"
-  "}"
-  "input{"
+    "}"
+    "input{"
     "-moz-appearance:none;"
     "-webkit-appearance:none;"
     "font-size:0.9em;"
     "margin:8px 0 auto"
-  "}"
-  ".lap{"
+    "}"
+    ".lap{"
     "visibility:collapse"
-  "}"
-  ".lap:target{"
+    "}"
+    ".lap:target{"
     "visibility:visible"
-  "}"
-  ".lap:target .overlap{"
+    "}"
+    ".lap:target .overlap{"
     "opacity:0.7;"
     "transition:0.3s"
-  "}"
-  ".lap:target .modal_button{"
+    "}"
+    ".lap:target .modal_button{"
     "opacity:1;"
     "transition:0.3s"
-  "}"
-  ".overlap{"
+    "}"
+    ".overlap{"
     "top:0;"
     "left:0;"
     "width:100%;"
@@ -79,8 +80,8 @@ const char AutoConnectCore<T>::_CSS_BASE[] PROGMEM = {
     "opacity:0;"
     "background:#000;"
     "z-index:1000"
-  "}"
-  ".modal_button{"
+    "}"
+    ".modal_button{"
     "border-radius:13px;"
     "background:#660033;"
     "color:#ffffcc;"
@@ -96,80 +97,76 @@ const char AutoConnectCore<T>::_CSS_BASE[] PROGMEM = {
     "position:fixed;"
     "opacity:0;"
     "z-index:1001"
-  "}"
-};
+    "}"};
 
 /**< non-marked list for UL */
-template<typename T>
+template <typename T>
 const char AutoConnectCore<T>::_CSS_UL[] PROGMEM = {
-  ".noorder,.exp{"
+    ".noorder,.exp{"
     "padding:0;"
     "list-style:none;"
     "display:table"
-  "}"
-  ".noorder li,.exp{"
+    "}"
+    ".noorder li,.exp{"
     "display:table-row-group"
-  "}"
-  ".noorder li label, .exp li{"
+    "}"
+    ".noorder li label, .exp li{"
     "display:table-cell;"
     "width:auto;"
     "text-align:right;"
     "padding:10px 0.5em"
-  "}"
-  ".noorder input[type=\"checkbox\"]{"
+    "}"
+    ".noorder input[type=\"checkbox\"]{"
     "-moz-appearance:checkbox;"
     "-webkit-appearance:checkbox"
-  "}"
-  ".noorder input[type=\"radio\"]{"
+    "}"
+    ".noorder input[type=\"radio\"]{"
     "cursor:pointer;"
     "-moz-appearance:radio;"
     "-webkit-appearance:radio"
-  "}"
-  ".noorder input[type=\"text\"],.noorder input[type=\"password\"],.noorder input[type=\"number\"],.noorder input[type=\"range\"]{"
+    "}"
+    ".noorder input[type=\"text\"],.noorder input[type=\"password\"],.noorder input[type=\"number\"],.noorder input[type=\"range\"]{"
     "width:auto"
-  "}"
-  ".noorder input[type=\"text\"]:invalid{"
+    "}"
+    ".noorder input[type=\"text\"]:invalid{"
     "background:#fce4d6"
-  "}"
-  ".noorder input[type=\"range\"]{"
+    "}"
+    ".noorder input[type=\"range\"]{"
     "height:7px;"
     "background:#dddddd;"
     "cursor:pointer"
-  "}"
-  ".magnify{"
+    "}"
+    ".magnify{"
     "display:inline-block"
-  "}"
-};
+    "}"};
 
 /**< Image icon for inline expansion, the lock mark. */
-template<typename T>
+template <typename T>
 const char AutoConnectCore<T>::_CSS_ICON_LOCK[] PROGMEM = {
-  ".img-lock{"
+    ".img-lock{"
     "width:22px;"
     "height:22px;"
     "margin-top:14px;"
     "float:right;"
     "background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAACXBIWXMAAAsTAAALEwEAmpwYAAAB1ElEQVRIibWVu0scURTGf3d2drBQFAWbbRQVCwuVLIZdi2gnWIiF/4GtKyuJGAJh8mgTcU0T8T8ICC6kiIVu44gvtFEQQWwsbExQJGHXmZtiZsOyzCN3Vz+4cDjfvec7j7l3QAF95onRZ54YKmdE1IbnS0c9mnAyAjkBxDy3LRHrjtRyu7OD52HntTAyvbw/HxP2hkCearrRb2WSCSuTTGi60S+QpzFhbwznDl/VVMHw0sF7hEjFbW2qkB38lfp8nNDipWcATil+uDM3cDWyeNRSijnfkHJnezb5Vkkgvbg3IOXD2e1ts93S+icnkZOAVaalZK3YQMa4L+pC6L1WduhYSeCf0PLBdxzOjZ93Lwvm6APAiLmlF1ubPiHotmaS41ExQjH0ZbfNM1NAFpgD0lVcICIrANqAVaAd+AFIYAy4BqaBG+Wsq5AH3vgk8xpYrzf4KLAZwhe8PYEIvQe4vc6H8Hnc2dQs0AFchvAXQGdEDF8s4A5TZS34BQqqQNaS1WMI3KD4WUbNoBJfce9CO7BSr4BfBe8A21vmUwh0VdjdTyHwscL+UK+AHxoD7FDoAX6/Cnpxn4ay/egCjcCL/w1chkqLakLQ/6ABhT57uAd+Vzv/Ara3iY6fK4WxAAAAAElFTkSuQmCC) no-repeat"
-  "}"
-};
+    "}"};
 
 /**< Image icon for inline expansion, the trash mark. */
-template<typename T>
+template <typename T>
 const char AutoConnectCore<T>::_CSS_ICON_TRASH[] PROGMEM = {
-  ".img-trash{"
+    ".img-trash{"
     "width:22px;"
     "height:22px;"
     "margin-top:14px;"
     "float:right;"
     "cursor:pointer;"
     "background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABYAAAAWCAYAAADEtGw7AAABhGlDQ1BJQ0MgcHJvZmlsZQAAKJF9kT1Iw0AcxV/TSkUqDnYQcQhSnSyIijpKFYtgobQVWnUwufQLmjQkKS6OgmvBwY/FqoOLs64OroIg+AHi6OSk6CIl/i8ptIjx4Lgf7+497t4BQqPCVDMwDqiaZaTiMTGbWxWDrxAQRAAzGJaYqSfSixl4jq97+Ph6F+VZ3uf+HL1K3mSATySeY7phEW8QT29aOud94jArSQrxOfGYQRckfuS67PIb56LDAs8MG5nUPHGYWCx2sNzBrGSoxFPEEUXVKF/Iuqxw3uKsVmqsdU/+wlBeW0lzneYQ4lhCAkmIkFFDGRVYiNKqkWIiRfsxD/+g40+SSyZXGYwcC6hCheT4wf/gd7dmYXLCTQrFgK4X2/4YAYK7QLNu29/Htt08AfzPwJXW9lcbwOwn6fW2FjkC+raBi+u2Ju8BlzvAwJMuGZIj+WkKhQLwfkbflAP6b4GeNbe31j5OH4AMdbV8AxwcAqNFyl73eHd3Z2//nmn19wONxHKyvZQ4mgAAAAZiS0dEAP8A/wD/oL2nkwAAAAlwSFlzAAAN1wAADdcBQiibeAAAALdJREFUOMvt1KEKAkEQBuBPMWkzWsRosWg2WEw2wTfQ6LNYfROLwSxWo81o02LQMsJxcJ4KguD9MOzMv8M/u8PsUqDAf2CMM25h5+CeopSzX8MBa6yCG2KAVhR5S3iDKuohsMcl9qpoR8FT8P20QCVDeIc5ljhm5DQwxeKdvnajn91ELOWnc146cbrIFr2Ik34myt8apUL4N4T3mMWa9J8ib9xG6OCKSXAPv/nJTUrxrG85tsn6Fu6nuijCLc4LEwAAAABJRU5ErkJggg==) no-repeat"
-  "}"
-};
+    "}"};
 
 /**< INPUT button and submit style */
-template<typename T>
+template <typename T>
 const char AutoConnectCore<T>::_CSS_INPUT_BUTTON[] PROGMEM = {
-  "input[type=\"button\"],input[type=\"submit\"],button[type=\"submit\"],button[type=\"button\"]{"
+    "input[type=\"button\"],input[type=\"submit\"],button[type=\"submit\"],button[type=\"button\"]{"
     "padding:8px 0.5em;"
     "font-weight:bold;"
     "letter-spacing:0.8px;"
@@ -178,47 +175,46 @@ const char AutoConnectCore<T>::_CSS_INPUT_BUTTON[] PROGMEM = {
     "border-radius:2px;"
     "margin-top:12px;"
     "cursor:pointer"
-  "}"
-  "input[type=\"button\"],button[type=\"button\"]{"
+    "}"
+    "input[type=\"button\"],button[type=\"button\"]{"
     "background-color:#1b5e20;"
     "border-color:#1b5e20;"
     "width:15em"
-  "}"
-  ".aux-page input[type=\"button\"],.aux-page button[type=\"button\"]{"
+    "}"
+    ".aux-page input[type=\"button\"],.aux-page button[type=\"button\"]{"
     "cursor:pointer;"
     "font-weight:normal;"
     "padding:8px 14px;"
     "margin:12px;"
     "width:auto"
-  "}"
-  "#sb[type=\"submit\"]{"
+    "}"
+    "#sb[type=\"submit\"]{"
     "padding:8px 0;"
     "width:13em"
-  "}"
-  "input[type=\"submit\"],button[type=\"submit\"]{"
+    "}"
+    "input[type=\"submit\"],button[type=\"submit\"]{"
     "padding:8px 30px;"
     "background-color:#006064;"
     "border-color:#006064"
-  "}"
-  "input[type=\"button\"],input[type=\"submit\"],button[type=\"submit\"]:focus,"
-  "input[type=\"button\"],input[type=\"submit\"],button[type=\"submit\"]:active{"
+    "}"
+    "input[type=\"button\"],input[type=\"submit\"],button[type=\"submit\"]:focus,"
+    "input[type=\"button\"],input[type=\"submit\"],button[type=\"submit\"]:active{"
     "outline:none;"
     "text-decoration:none"
-  "}"
-};
+    "}"};
 
 /**< INPUT text style */
-template<typename T>
+template <typename T>
 const char AutoConnectCore<T>::_CSS_INPUT_TEXT[] PROGMEM = {
-  "input[type=\"text\"],input[type=\"password\"],input[type=\"number\"],.aux-page select{"
+    "input[type=\"text\"],input[type=\"password\"],input[type=\"number\"],.aux-page select{"
     "background-color:#fff;"
     "border:1px solid #ccc;"
     "border-radius:2px;"
     "color:#444;"
     "margin:8px 0 8px 0;"
     "padding:10px"
-  "}"
-  "input[type=\"text\"],input[type=\"password\"],input[type=\"number\"]{"
+    "}"
+    "input[type=\"text\"],input[type=\"password\"],input[type=\"number\"]{"
     "font-weight:300;"
     "width:auto;"
     "-webkit-transition:all 0.20s ease-in;"
@@ -226,101 +222,99 @@ const char AutoConnectCore<T>::_CSS_INPUT_TEXT[] PROGMEM = {
     "-o-transition:all 0.20s ease-in;"
     "-ms-transition:all 0.20s ease-in;"
     "transition:all 0.20s ease-in"
-  "}"
-  "input[type=\"text\"]:focus,input[type=\"password\"]:focus,input[type=\"number\"]:focus{"
+    "}"
+    "input[type=\"text\"]:focus,input[type=\"password\"]:focus,input[type=\"number\"]:focus{"
     "outline:none;"
     "border-color:#5C9DED;"
     "box-shadow:0 0 3px #4B8CDC"
-  "}"
-  "input.error,input.error:focus{"
+    "}"
+    "input.error,input.error:focus{"
     "border-color:#ED5564;"
     "color:#D9434E;"
     "box-shadow:0 0 3px #D9434E"
-  "}"
-  "input:disabled{"
+    "}"
+    "input:disabled{"
     "opacity:0.6;"
     "background-color:#f7f7f7"
-  "}"
-  "input:disabled:hover{"
+    "}"
+    "input:disabled:hover{"
     "cursor:not-allowed"
-  "}"
-  "input.error::-webkit-input-placeholder,"
-  "input.error::-moz-placeholder,"
-  "input.error::-ms-input-placeholder{"
+    "}"
+    "input.error::-webkit-input-placeholder,"
+    "input.error::-moz-placeholder,"
+    "input.error::-ms-input-placeholder{"
     "color:#D9434E"
-  "}"
-  ".aux-page label{"
+    "}"
+    ".aux-page label{"
     "display:inline;"
     "padding:10px 0.5em;"
     "cursor:pointer"
-  "}"
-};
+    "}"};
 
 /**< TABLE style */
-template<typename T>
+template <typename T>
 const char AutoConnectCore<T>::_CSS_TABLE[] PROGMEM = {
-  "table{"
+    "table{"
     "border-collapse:collapse;"
     "border-spacing:0;"
     "border:1px solid #ddd;"
     "color:#444;"
     "background-color:#fff;"
     "margin-bottom:20px"
-  "}"
-  "table.info,"
-  "table.info>tfoot,"
-  "table.info>thead{"
+    "}"
+    "table.info,"
+    "table.info>tfoot,"
+    "table.info>thead{"
     "width:100%;"
     "border-color:#5C9DED"
-  "}"
-  "table.info>thead{"
+    "}"
+    "table.info>thead{"
     "background-color:#5C9DED"
-  "}"
-  "table.info>thead>tr>th{"
+    "}"
+    "table.info>thead>tr>th{"
     "color:#fff"
-  "}"
-  "td,"
-  "th{"
+    "}"
+    "td,"
+    "th{"
     "padding:10px 22px"
-  "}"
-  "thead{"
+    "}"
+    "thead{"
     "background-color:#f3f3f3;"
     "border-bottom:1px solid #ddd"
-  "}"
-  "thead>tr>th{"
+    "}"
+    "thead>tr>th{"
     "font-weight:400;"
     "text-align:left"
-  "}"
-  "tfoot{"
+    "}"
+    "tfoot{"
     "border-top:1px solid #ddd"
-  "}"
-  "tbody,"
-  "tbody>tr:nth-child(odd){"
+    "}"
+    "tbody,"
+    "tbody>tr:nth-child(odd){"
     "background-color:#fff"
-  "}"
-  "tbody>tr>td,"
-  "tfoot>tr>td{"
+    "}"
+    "tbody>tr>td,"
+    "tfoot>tr>td{"
     "font-weight:300;"
     "font-size:.88em"
-  "}"
-  "tbody>tr:nth-child(even){"
+    "}"
+    "tbody>tr:nth-child(even){"
     "background-color:#f7f7f7"
-  "}"
+    "}"
     "table.info tbody>tr:nth-child(even){"
     "background-color:#EFF5FD"
-  "}"
-};
+    "}"};
 
 /**< SVG animation for spinner */
-template<typename T>
+template <typename T>
 const char AutoConnectCore<T>::_CSS_SPINNER[] PROGMEM = {
-  ".spinner{"
+    ".spinner{"
     "width:40px;"
     "height:40px;"
     "position:relative;"
     "margin:100px auto"
-  "}"
-  ".dbl-bounce1, .dbl-bounce2{"
+    "}"
+    ".dbl-bounce1, .dbl-bounce2{"
     "width:100%;"
     "height:100%;"
     "border-radius:50%;"
@@ -331,131 +325,130 @@ const char AutoConnectCore<T>::_CSS_SPINNER[] PROGMEM = {
     "left:0;"
     "-webkit-animation:sk-bounce 2.0s infinite ease-in-out;"
     "animation:sk-bounce 2.0s infinite ease-in-out"
-  "}"
-  ".dbl-bounce2{"
+    "}"
+    ".dbl-bounce2{"
     "-webkit-animation-delay:-1.0s;"
     "animation-delay:-1.0s"
-  "}"
-  "@-webkit-keyframes sk-bounce{"
+    "}"
+    "@-webkit-keyframes sk-bounce{"
     "0%, 100%{-webkit-transform:scale(0.0)}"
     "50%{-webkit-transform:scale(1.0)}"
-  "}"
-  "@keyframes sk-bounce{"
-    "0%,100%{"
-      "transform:scale(0.0);"
-      "-webkit-transform:scale(0.0);"
-    "}50%{"
-      "transform:scale(1.0);"
-      "-webkit-transform:scale(1.0);"
     "}"
-  "}"
-};
+    "@keyframes sk-bounce{"
+    "0%,100%{"
+    "transform:scale(0.0);"
+    "-webkit-transform:scale(0.0);"
+    "}50%{"
+    "transform:scale(1.0);"
+    "-webkit-transform:scale(1.0);"
+    "}"
+    "}"};
 
 /**< Common menu bar. This style quotes LuxBar. */
 /**< balzss/luxbar is licensed under the MIT License https://github.com/balzss/luxbar */
-template<typename T>
+template <typename T>
 const char AutoConnectCore<T>::_CSS_LUXBAR[] PROGMEM = {
-  ".lb-fixed{"
+    ".lb-fixed{"
     "width:100%;"
     "position:fixed;"
     "top:0;"
     "left:0;"
     "z-index:1000;"
     "box-shadow:0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24)"
-  "}"
-  ".lb-burger span,"
-  ".lb-burger span::before,"
-  ".lb-burger span::after{"
+    "}"
+    ".lb-burger span,"
+    ".lb-burger span::before,"
+    ".lb-burger span::after{"
     "display:block;"
     "height:2px;"
     "width:26px;"
     "transition:0.6s ease"
-  "}"
-  ".lb-cb:checked~.lb-menu li .lb-burger span{"
+    "}"
+    ".lb-cb:checked~.lb-menu li .lb-burger span{"
     "background-color:transparent"
-  "}"
-  ".lb-cb:checked~.lb-menu li .lb-burger span::before,"
-  ".lb-cb:checked~.lb-menu li .lb-burger span::after{"
+    "}"
+    ".lb-cb:checked~.lb-menu li .lb-burger span::before,"
+    ".lb-cb:checked~.lb-menu li .lb-burger span::after{"
     "margin-top:0"
-  "}"
-  ".lb-header{"
+    "}"
+    ".lb-header{"
     "display:flex;"
     "flex-direction:row;"
     "justify-content:space-between;"
     "align-items:center;"
     "height:58px"
-  "}"
-  ".lb-menu-right .lb-burger{"
+    "}"
+    ".lb-menu-right .lb-burger{"
     "margin-left:auto"
-  "}"
-  ".lb-brand{"
+    "}"
+    ".lb-brand{"
     "font-size:1.6em;"
     "padding:18px 24px 18px 24px"
-  "}"
-  ".lb-menu{"
+    "}"
+    ".lb-menu{"
     "min-height:58px;"
     "transition:0.6s ease;"
     "width:100%"
-  "}"
-  ".lb-navigation{"
+    "}"
+    ".lb-navigation{"
     "display:flex;"
     "flex-direction:column;"
     "list-style:none;"
     "padding-left:0;"
     "margin:0"
-  "}"
-  ".lb-menu a,"
-  ".lb-item a{"
+    "}"
+    ".lb-menu a,"
+    ".lb-item a{"
     "text-decoration:none;"
     "color:inherit;"
     "cursor:pointer"
-  "}"
-  ".lb-item{"
+    "}"
+    ".lb-item{"
     "height:58px"
-  "}"
-  ".lb-item a{"
+    "}"
+    ".lb-item a{"
     "padding:18px 24px 18px 24px;"
     "display:block"
-  "}"
-  ".lb-burger{"
+    "}"
+    ".lb-burger{"
     "padding:18px 24px 18px 24px;"
     "position:relative;"
     "cursor:pointer"
-  "}"
-  ".lb-burger span::before,"
-  ".lb-burger span::after{"
+    "}"
+    ".lb-burger span::before,"
+    ".lb-burger span::after{"
     "content:'';"
     "position:absolute"
-  "}"
-  ".lb-burger span::before{"
+    "}"
+    ".lb-burger span::before{"
     "margin-top:-8px"
-  "}"
-  ".lb-burger span::after{"
+    "}"
+    ".lb-burger span::after{"
     "margin-top:8px"
-  "}"
-  ".lb-cb{"
+    "}"
+    ".lb-cb{"
     "display:none"
-  "}"
-  ".lb-cb:not(:checked)~.lb-menu{"
+    "}"
+    ".lb-cb:not(:checked)~.lb-menu{"
     "overflow:hidden;"
     "height:58px"
-  "}"
-  ".lb-cb:checked~.lb-menu{"
+    "}"
+    ".lb-cb:checked~.lb-menu{"
     "transition:height 0.6s ease;"
     "height:100vh;"
     "overflow:auto"
-  "}"
-  ".dropdown{"
+    "}"
+    ".dropdown{"
     "position:relative;"
     "height:auto;"
     "min-height:58px"
-  "}"
-  ".dropdown:hover>ul{"
+    "}"
+    ".dropdown:hover>ul{"
     "position:relative;"
     "display:block;"
     "min-width:100%"
-  "}"
-  ".dropdown>a::after{"
+    "}"
+    ".dropdown>a::after{"
     "position:absolute;"
     "content:'';"
     "right:10px;"
@@ -463,470 +456,463 @@ const char AutoConnectCore<T>::_CSS_LUXBAR[] PROGMEM = {
     "border-width:5px 5px 0;"
     "border-color:transparent;"
     "border-style:solid"
-  "}"
-  ".dropdown>ul{"
+    "}"
+    ".dropdown>ul{"
     "display:block;"
     "overflow-x:hidden;"
     "list-style:none;"
     "padding:0"
-  "}"
-  ".dropdown>ul .lb-item{"
+    "}"
+    ".dropdown>ul .lb-item{"
     "min-width:100%;"
     "height:29px;"
     "padding:5px 10px 5px 40px"
-  "}"
-  ".dropdown>ul .lb-item a{"
+    "}"
+    ".dropdown>ul .lb-item a{"
     "min-height:29px;"
     "line-height:29px;"
     "padding:0"
-  "}"
-  "@media screen and (min-width:768px){"
+    "}"
+    "@media screen and (min-width:768px){"
     ".lb-navigation{"
-      "flex-flow:row;"
-      "justify-content:flex-end;"
+    "flex-flow:row;"
+    "justify-content:flex-end;"
     "}"
     ".lb-burger{"
-      "display:none;"
+    "display:none;"
     "}"
     ".lb-cb:not(:checked)~.lb-menu{"
-      "overflow:visible;"
+    "overflow:visible;"
     "}"
     ".lb-cb:checked~.lb-menu{"
-      "height:58px;"
+    "height:58px;"
     "}"
     ".lb-menu .lb-item{"
-      "border-top:0;"
+    "border-top:0;"
     "}"
     ".lb-menu-right .lb-header{"
-      "margin-right:auto;"
+    "margin-right:auto;"
     "}"
     ".dropdown{"
-      "height:58px;"
+    "height:58px;"
     "}"
     ".dropdown:hover>ul{"
-      "position:absolute;"
-      "left:0;"
-      "top:58px;"
-      "padding:0;"
+    "position:absolute;"
+    "left:0;"
+    "top:58px;"
+    "padding:0;"
     "}"
     ".dropdown>ul{"
-      "display:none;"
+    "display:none;"
     "}"
     ".dropdown>ul .lb-item{"
-      "padding:5px 10px;"
+    "padding:5px 10px;"
     "}"
     ".dropdown>ul .lb-item a{"
-      "white-space:nowrap;"
+    "white-space:nowrap;"
     "}"
-  "}"
-  ".lb-cb:checked+.lb-menu .lb-burger-dblspin span::before{"
+    "}"
+    ".lb-cb:checked+.lb-menu .lb-burger-dblspin span::before{"
     "transform:rotate(225deg)"
-  "}"
-  ".lb-cb:checked+.lb-menu .lb-burger-dblspin span::after{"
+    "}"
+    ".lb-cb:checked+.lb-menu .lb-burger-dblspin span::after{"
     "transform:rotate(-225deg)"
-  "}"
-  ".lb-menu-material,"
-  ".lb-menu-material .dropdown ul{"
+    "}"
+    ".lb-menu-material,"
+    ".lb-menu-material .dropdown ul{"
     "background-color:" AUTOCONNECT_MENUCOLOR_BACKGROUND ";"
     "color:" AUTOCONNECT_MENUCOLOR_TEXT
-  "}"
-  ".lb-menu-material .active,"
-  ".lb-menu-material .lb-item:hover{"
+    "}"
+    ".lb-menu-material .active,"
+    ".lb-menu-material .lb-item:hover{"
     "background-color:" AUTOCONNECT_MENUCOLOR_ACTIVE
-  "}"
-  ".lb-menu-material .lb-burger span,"
-  ".lb-menu-material .lb-burger span::before,"
-  ".lb-menu-material .lb-burger span::after{"
+    "}"
+    ".lb-menu-material .lb-burger span,"
+    ".lb-menu-material .lb-burger span::before,"
+    ".lb-menu-material .lb-burger span::after{"
     "background-color:" AUTOCONNECT_MENUCOLOR_TEXT
-  "}"
-};
+    "}"};
 
 /**< Common html document header. */
-template<typename T>
+template <typename T>
 const char AutoConnectCore<T>::_ELM_HTML_HEAD[] PROGMEM = {
-  "<!DOCTYPE html>"
-  "<html>"
-  "<head>"
-  "<meta charset=\"UTF-8\" name=\"viewport\" content=\"width=device-width,initial-scale=1\">"
-};
+    "<!DOCTYPE html>"
+    "<html>"
+    "<head>"
+    "<meta charset=\"UTF-8\" name=\"viewport\" content=\"width=device-width,initial-scale=1\">"};
 
 /**< LuxBar menu element. */
-template<typename T>
-const char  AutoConnectCore<T>::_ELM_MENU_PRE[] PROGMEM = {
-  "<header id=\"lb\" class=\"lb-fixed\">"
+template <typename T>
+const char AutoConnectCore<T>::_ELM_MENU_PRE[] PROGMEM = {
+    "<header id=\"lb\" class=\"lb-fixed\">"
     "<input type=\"checkbox\" class=\"lb-cb\" id=\"lb-cb\"/>"
     "<div class=\"lb-menu lb-menu-right lb-menu-material\">"
-      "<ul class=\"lb-navigation\">"
-        "<li class=\"lb-header\">"
-          "<a href=\"BOOT_URI\" class=\"lb-brand\">MENU_TITLE</a>"
-          "<label class=\"lb-burger lb-burger-dblspin\" id=\"lb-burger\" for=\"lb-cb\"><span></span></label>"
-        "</li>"
-        "MENU_LIST"
-};
+    "<ul class=\"lb-navigation\">"
+    "<li class=\"lb-header\">"
+    "<a href=\"BOOT_URI\" class=\"lb-brand\">MENU_TITLE</a>"
+    "<label class=\"lb-burger lb-burger-dblspin\" id=\"lb-burger\" for=\"lb-cb\"><span></span></label>"
+    "</li>"
+    "MENU_LIST"};
 
-template<typename T>
-const char  AutoConnectCore<T>::_ELM_MENU_POST[] PROGMEM = {
-        "MENU_HOME"
-        "MENU_DEVINFO"
-      "</ul>"
+template <typename T>
+const char AutoConnectCore<T>::_ELM_MENU_POST[] PROGMEM = {
+    "MENU_HOME"
+    "MENU_DEVINFO"
+    "</ul>"
     "</div>"
     "<div class=\"lap\" id=\"rdlg\"><a href=\"#reset\" class=\"overlap\"></a>"
-      "<div class=\"modal_button\"><h2><a href=\"" AUTOCONNECT_URI_RESET "\" class=\"modal_button\">" AUTOCONNECT_BUTTONLABEL_RESET "</a></h2></div>"
+    "<div class=\"modal_button\"><h2><a href=\"" AUTOCONNECT_URI_RESET "\" class=\"modal_button\">" AUTOCONNECT_BUTTONLABEL_RESET "</a></h2></div>"
     "</div>"
-  "</header>"
-};
+    "</header>"};
 
 /**< The 404 page content. */
-template<typename T>
-const char  AutoConnectCore<T>::_PAGE_404[] PROGMEM = {
-  "{{HEAD}}"
+template <typename T>
+const char AutoConnectCore<T>::_PAGE_404[] PROGMEM = {
+    "{{HEAD}}"
     "<title>" AUTOCONNECT_PAGETITLE_NOTFOUND "</title>"
-  "</head>"
-  "<body>"
+    "</head>"
+    "<body>"
     "404 Not found"
-  "</body>"
-  "</html>"
-};
+    "</body>"
+    "</html>"};
 
 /**< The page that started the reset. */
-template<typename T>
-const char  AutoConnectCore<T>::_PAGE_RESETTING[] PROGMEM = {
-  "{{HEAD}}"
+template <typename T>
+const char AutoConnectCore<T>::_PAGE_RESETTING[] PROGMEM = {
+    "{{HEAD}}"
     "<meta http-equiv=\"refresh\" content=\"{{UPTIME}};url={{BOOTURI}}\">"
     "<title>" AUTOCONNECT_PAGETITLE_RESETTING "</title>"
-  "</head>"
-  "<body>"
+    "</head>"
+    "<body>"
     "<h3><div style=\"display:inline-block\"><span>{{RESET}}</span><span id=\"cd\"></span></div></h3>"
     "<script type=\"text/javascript\">"
-      "window.onload=function(){"
-        "var t={{UPTIME}},elm=document.getElementById(\"cd\"),ct=setInterval(function(){--t?elm.innerHTML=String(t)+\"&nbsp;sec.\":(elm.innerHTML=\"expiry\",clearInterval(ct))},1e3);"
-      "};"
+    "window.onload=function(){"
+    "var t={{UPTIME}},elm=document.getElementById(\"cd\"),ct=setInterval(function(){--t?elm.innerHTML=String(t)+\"&nbsp;sec.\":(elm.innerHTML=\"expiry\",clearInterval(ct))},1e3);"
+    "};"
     "</script>"
-  "</body>"
-  "</html>"
-};
+    "</body>"
+    "</html>"};
 
 /**< AutoConnect portal page. */
-template<typename T>
-const char  AutoConnectCore<T>::_PAGE_STAT[] PROGMEM = {
-  "{{HEAD}}"
+template <typename T>
+const char AutoConnectCore<T>::_PAGE_STAT[] PROGMEM = {
+    "{{HEAD}}"
     "<title>" AUTOCONNECT_PAGETITLE_STATISTICS "</title>"
     "<style type=\"text/css\">"
-      "{{CSS_BASE}}"
-      "{{CSS_TABLE}}"
-      "{{CSS_LUXBAR}}"
+    "{{CSS_BASE}}"
+    "{{CSS_TABLE}}"
+    "{{CSS_LUXBAR}}"
     "</style>"
-  "</head>"
-  "<body style=\"padding-top:58px;\">"
+    "</head>"
+    "<body style=\"padding-top:58px;\">"
     "<div class=\"container\">"
-      "{{MENU_PRE}}"
-      "{{MENU_AUX}}"
-      "{{MENU_POST}}"
-      "<div>"
-        "<table class=\"info\" style=\"border:none;\">"
-          "<tbody>"
-          "<tr>"
-            "<td>" AUTOCONNECT_PAGESTATS_ESTABLISHEDCONNECTION "</td>"
-            "<td>{{ESTAB_SSID}}</td>"
-          "</tr>"
-          "<tr>"
-            "<td>" AUTOCONNECT_PAGESTATS_MODE "</td>"
-            "<td>{{WIFI_MODE}}({{WIFI_STATUS}})</td>"
-          "</tr>"
-          "<tr>"
-            "<td>" AUTOCONNECT_PAGESTATS_IP "</td>"
-            "<td>{{LOCAL_IP}}</td>"
-          "</tr>"
-          "<tr>"
-            "<td>" AUTOCONNECT_PAGESTATS_GATEWAY "</td>"
-            "<td>{{GATEWAY}}</td>"
-          "</tr>"
-          "<tr>"
-            "<td>" AUTOCONNECT_PAGESTATS_SUBNETMASK "</td>"
-            "<td>{{NETMASK}}</td>"
-          "</tr>"
-          "<tr>"
-            "<td>" AUTOCONNECT_PAGESTATS_SOFTAPIP "</td>"
-            "<td>{{SOFTAP_IP}}</td>"
-          "</tr>"
-          "<tr>"
-            "<td>" AUTOCONNECT_PAGESTATS_APMAC "</td>"
-            "<td>{{AP_MAC}}</td>"
-          "</tr>"
-          "<tr>"
-            "<td>" AUTOCONNECT_PAGESTATS_STAMAC "</td>"
-            "<td>{{STA_MAC}}</td>"
-          "</tr>"
-          "<tr>"
-            "<td>" AUTOCONNECT_PAGESTATS_CHANNEL "</td>"
-            "<td>{{CHANNEL}}</td>"
-          "</tr>"
-          "<tr>"
-            "<td>" AUTOCONNECT_PAGESTATS_DBM "</td>"
-            "<td>{{DBM}}</td>"
-          "</tr>"
-          "<tr>"
-            "<td>" AUTOCONNECT_PAGESTATS_CHIPID "</td>"
-            "<td>{{CHIP_ID}}</td>"
-          "</tr>"
-          "<tr>"
-            "<td>" AUTOCONNECT_PAGESTATS_CPUFREQ "</td>"
-            "<td>{{CPU_FREQ}}MHz</td>"
-          "</tr>"
-          "<tr>"
-            "<td>" AUTOCONNECT_PAGESTATS_FLASHSIZE "</td>"
-            "<td>{{FLASH_SIZE}}</td>"
-          "</tr>"
-          "<tr>"
-            "<td>" AUTOCONNECT_PAGESTATS_FREEMEM "</td>"
-            "<td>{{FREE_HEAP}}</td>"
-          "</tr>"
-          "</tbody>"
-        "</table>"
-      "</div>"
+    "{{MENU_PRE}}"
+    "{{MENU_AUX}}"
+    "{{MENU_POST}}"
+    "<div>"
+    "<table class=\"info\" style=\"border:none;\">"
+    "<tbody>"
+    "<tr>"
+    "<td>" AUTOCONNECT_PAGESTATS_ESTABLISHEDCONNECTION "</td>"
+    "<td>{{ESTAB_SSID}}</td>"
+    "</tr>"
+    "<tr>"
+    "<td>" AUTOCONNECT_PAGESTATS_MODE "</td>"
+    "<td>{{WIFI_MODE}}({{WIFI_STATUS}})</td>"
+    "</tr>"
+    "<tr>"
+    "<td>" AUTOCONNECT_PAGESTATS_IP "</td>"
+    "<td>{{LOCAL_IP}}</td>"
+    "</tr>"
+    "<tr>"
+    "<td>" AUTOCONNECT_PAGESTATS_GATEWAY "</td>"
+    "<td>{{GATEWAY}}</td>"
+    "</tr>"
+    "<tr>"
+    "<td>" AUTOCONNECT_PAGESTATS_SUBNETMASK "</td>"
+    "<td>{{NETMASK}}</td>"
+    "</tr>"
+    "<tr>"
+    "<td>" AUTOCONNECT_PAGESTATS_SOFTAPIP "</td>"
+    "<td>{{SOFTAP_IP}}</td>"
+    "</tr>"
+    "<tr>"
+    "<td>" AUTOCONNECT_PAGESTATS_APMAC "</td>"
+    "<td>{{AP_MAC}}</td>"
+    "</tr>"
+    "<tr>"
+    "<td>" AUTOCONNECT_PAGESTATS_STAMAC "</td>"
+    "<td>{{STA_MAC}}</td>"
+    "</tr>"
+    "<tr>"
+    "<td>" AUTOCONNECT_PAGESTATS_CHANNEL "</td>"
+    "<td>{{CHANNEL}}</td>"
+    "</tr>"
+    "<tr>"
+    "<td>" AUTOCONNECT_PAGESTATS_DBM "</td>"
+    "<td>{{DBM}}</td>"
+    "</tr>"
+    "<tr>"
+    "<td>" AUTOCONNECT_PAGESTATS_CHIPID "</td>"
+    "<td>{{CHIP_ID}}</td>"
+    "</tr>"
+    "<tr>"
+    "<td>" AUTOCONNECT_PAGESTATS_CPUFREQ "</td>"
+    "<td>{{CPU_FREQ}}MHz</td>"
+    "</tr>"
+    "<tr>"
+    "<td>" AUTOCONNECT_PAGESTATS_FLASHSIZE "</td>"
+    "<td>{{FLASH_SIZE}}</td>"
+    "</tr>"
+    "<tr>"
+    "<td>" AUTOCONNECT_PAGESTATS_FREEMEM "</td>"
+    "<td>{{FREE_HEAP}}</td>"
+    "</tr>"
+    "<tr>"
+    "<td>" AUTOCONNECT_PAGESTATS_SYSTEM_UPTIME "</td>"
+    "<td>{{SYSTEM_UPTIME}}</td>"
+    "</tr>"
+    "</tbody>"
+    "</table>"
     "</div>"
-  "</body>"
-  "</html>"
-};
+    "</div>"
+    "</body>"
+    "</html>"};
 
 /**< A page that specifies the new configuration. */
-template<typename T>
-const char  AutoConnectCore<T>::_PAGE_CONFIGNEW[] PROGMEM = {
-  "{{HEAD}}"
+template <typename T>
+const char AutoConnectCore<T>::_PAGE_CONFIGNEW[] PROGMEM = {
+    "{{HEAD}}"
     "<title>" AUTOCONNECT_PAGETITLE_CONFIG "</title>"
     "<style type=\"text/css\">"
-      "{{CSS_BASE}}"
-      "{{CSS_ICON_LOCK}}"
-      "{{CSS_UL}}"
-      "{{CSS_INPUT_BUTTON}}"
-      "{{CSS_INPUT_TEXT}}"
-      "{{CSS_LUXBAR}}"
+    "{{CSS_BASE}}"
+    "{{CSS_ICON_LOCK}}"
+    "{{CSS_UL}}"
+    "{{CSS_INPUT_BUTTON}}"
+    "{{CSS_INPUT_TEXT}}"
+    "{{CSS_LUXBAR}}"
     "</style>"
-  "</head>"
-  "<body style=\"padding-top:58px;\">"
+    "</head>"
+    "<body style=\"padding-top:58px;\">"
     "<div class=\"container\">"
-      "{{MENU_PRE}}"
-      "{{MENU_AUX}}"
-      "{{MENU_POST}}"
-      "<div class=\"base-panel\">"
-        "<form action=\"" AUTOCONNECT_URI_CONNECT "\" method=\"post\">"
-          "<button style=\"width:0;height:0;padding:0;border:0;margin:0\" aria-hidden=\"true\" tabindex=\"-1\" type=\"submit\" name=\"apply\" value=\"apply\"></button>"
-          "{{LIST_SSID}}"
-          "<div style=\"margin:16px 0 8px 0;border-bottom:solid 1px #263238;\">" AUTOCONNECT_PAGECONFIG_TOTAL "{{SSID_COUNT}} " AUTOCONNECT_PAGECONFIG_HIDDEN "{{HIDDEN_COUNT}}</div>"
-          "<ul class=\"noorder\">"
-            "<li>"
-              "<label for=\"ssid\">" AUTOCONNECT_PAGECONFIG_SSID "</label>"
-              "<input id=\"ssid\" type=\"text\" name=\"" AUTOCONNECT_PARAMID_SSID "\" placeholder=\"" AUTOCONNECT_PAGECONFIG_SSID "\">"
-            "</li>"
-            "<li>"
-              "<label for=\"passphrase\">" AUTOCONNECT_PAGECONFIG_PASSPHRASE "</label>"
-              "<input id=\"passphrase\" type=\"password\" name=\"" AUTOCONNECT_PARAMID_PASS "\" placeholder=\"" AUTOCONNECT_PAGECONFIG_PASSPHRASE "\">"
-            "</li>"
-            "<li>"
-              "<label for=\"dhcp\">" AUTOCONNECT_PAGECONFIG_ENABLEDHCP "</label>"
-              "<input id=\"dhcp\" type=\"checkbox\" name=\"dhcp\" value=\"en\" checked onclick=\"vsw(this.checked);\">"
-            "</li>"
-            "{{CONFIG_IP}}"
-            "<li><input type=\"submit\" name=\"apply\" value=\"" AUTOCONNECT_PAGECONFIG_APPLY "\"></li>"
-          "</ul>"
-        "</form>"
-      "</div>"
+    "{{MENU_PRE}}"
+    "{{MENU_AUX}}"
+    "{{MENU_POST}}"
+    "<div class=\"base-panel\">"
+    "<form action=\"" AUTOCONNECT_URI_CONNECT "\" method=\"post\">"
+    "<button style=\"width:0;height:0;padding:0;border:0;margin:0\" aria-hidden=\"true\" tabindex=\"-1\" type=\"submit\" name=\"apply\" value=\"apply\"></button>"
+    "{{LIST_SSID}}"
+    "<div style=\"margin:16px 0 8px 0;border-bottom:solid 1px #263238;\">" AUTOCONNECT_PAGECONFIG_TOTAL "{{SSID_COUNT}} " AUTOCONNECT_PAGECONFIG_HIDDEN "{{HIDDEN_COUNT}}</div>"
+    "<ul class=\"noorder\">"
+    "<li>"
+    "<label for=\"ssid\">" AUTOCONNECT_PAGECONFIG_SSID "</label>"
+    "<input id=\"ssid\" type=\"text\" name=\"" AUTOCONNECT_PARAMID_SSID "\" placeholder=\"" AUTOCONNECT_PAGECONFIG_SSID "\">"
+    "</li>"
+    "<li>"
+    "<label for=\"passphrase\">" AUTOCONNECT_PAGECONFIG_PASSPHRASE "</label>"
+    "<input id=\"passphrase\" type=\"password\" name=\"" AUTOCONNECT_PARAMID_PASS "\" placeholder=\"" AUTOCONNECT_PAGECONFIG_PASSPHRASE "\">"
+    "</li>"
+    "<li>"
+    "<label for=\"dhcp\">" AUTOCONNECT_PAGECONFIG_ENABLEDHCP "</label>"
+    "<input id=\"dhcp\" type=\"checkbox\" name=\"dhcp\" value=\"en\" checked onclick=\"vsw(this.checked);\">"
+    "</li>"
+    "{{CONFIG_IP}}"
+    "<li><input type=\"submit\" name=\"apply\" value=\"" AUTOCONNECT_PAGECONFIG_APPLY "\"></li>"
+    "</ul>"
+    "</form>"
     "</div>"
-  "<script type=\"text/javascript\">"
+    "</div>"
+    "<script type=\"text/javascript\">"
     "window.onload=function(){"
-      "['" AUTOCONNECT_PARAMID_STAIP "','" AUTOCONNECT_PARAMID_GTWAY "','" AUTOCONNECT_PARAMID_NTMSK "','" AUTOCONNECT_PARAMID_DNS1 "','" AUTOCONNECT_PARAMID_DNS2 "'].forEach(function(n,o,t){"
-        "io=document.getElementById(n),io.placeholder='0.0.0.0',io.pattern='^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$'});"
-      "vsw(true)};"
+    "['" AUTOCONNECT_PARAMID_STAIP "','" AUTOCONNECT_PARAMID_GTWAY "','" AUTOCONNECT_PARAMID_NTMSK "','" AUTOCONNECT_PARAMID_DNS1 "','" AUTOCONNECT_PARAMID_DNS2 "'].forEach(function(n,o,t){"
+    "io=document.getElementById(n),io.placeholder='0.0.0.0',io.pattern='^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$'});"
+    "vsw(true)};"
     "function onFocus(e){"
-      "document.getElementById('ssid').value=e,document.getElementById('passphrase').focus()"
+    "document.getElementById('ssid').value=e,document.getElementById('passphrase').focus()"
     "}"
     "function vsw(e){"
-      "var t;t=e?'none':'table-row';for(const n of document.getElementsByClassName('exp'))n.style.display=t,n.getElementsByTagName('input')[0].disabled=e;e||document.getElementById('sip').focus()"
+    "var t;t=e?'none':'table-row';for(const n of document.getElementsByClassName('exp'))n.style.display=t,n.getElementsByTagName('input')[0].disabled=e;e||document.getElementById('sip').focus()"
     "}"
-  "</script>"
-  "</body>"
-  "</html>"
-};
+    "</script>"
+    "</body>"
+    "</html>"};
 
 /**< A page that reads stored authentication information and starts connection. */
-template<typename T>
-const char  AutoConnectCore<T>::_PAGE_OPENCREDT[] PROGMEM = {
-  "{{HEAD}}"
+template <typename T>
+const char AutoConnectCore<T>::_PAGE_OPENCREDT[] PROGMEM = {
+    "{{HEAD}}"
     "<title>" AUTOCONNECT_PAGETITLE_CREDENTIALS "</title>"
     "<style type=\"text/css\">"
-      "{{CSS_BASE}}"
-      "{{CSS_ICON_LOCK}}"
-      "{{CSS_ICON_TRASH}}"
-      "{{CSS_INPUT_BUTTON}}"
-      "{{CSS_LUXBAR}}"
+    "{{CSS_BASE}}"
+    "{{CSS_ICON_LOCK}}"
+    "{{CSS_ICON_TRASH}}"
+    "{{CSS_INPUT_BUTTON}}"
+    "{{CSS_LUXBAR}}"
     "</style>"
-  "</head>"
-  "<body style=\"padding-top:58px;\">"
+    "</head>"
+    "<body style=\"padding-top:58px;\">"
     "<div class=\"container\">"
-      "{{MENU_PRE}}"
-      "{{MENU_AUX}}"
-      "{{MENU_POST}}"
-      "<div class=\"base-panel\">"
-        "<form id=\"_sid\" action=\"" AUTOCONNECT_URI_CONNECT "\" method=\"post\">"
-          "{{OPEN_SSID}}"
-        "</form>"
-      "</div>"
+    "{{MENU_PRE}}"
+    "{{MENU_AUX}}"
+    "{{MENU_POST}}"
+    "<div class=\"base-panel\">"
+    "<form id=\"_sid\" action=\"" AUTOCONNECT_URI_CONNECT "\" method=\"post\">"
+    "{{OPEN_SSID}}"
+    "</form>"
+    "</div>"
     "</div>"
     "<script type=\"text/javascript\">"
-      "function crdel(e){if(confirm(`${e} " AUTOCONNECT_TEXT_DELETECREDENTIAL "`)){var t=document.getElementById('_sid');t.setAttribute('action','" AUTOCONNECT_URI_DELETE "');var i=document.createElement('input');i.setAttribute('type','hidden'),i.setAttribute('name','del'),i.setAttribute('value',e),t.appendChild(i),t.submit()}}"
+    "function crdel(e){if(confirm(`${e} " AUTOCONNECT_TEXT_DELETECREDENTIAL "`)){var t=document.getElementById('_sid');t.setAttribute('action','" AUTOCONNECT_URI_DELETE "');var i=document.createElement('input');i.setAttribute('type','hidden'),i.setAttribute('name','del'),i.setAttribute('value',e),t.appendChild(i),t.submit()}}"
     "</script>"
-  "</body>"
-  "</html>"
-};
+    "</body>"
+    "</html>"};
 
 /**< A page that informs during a connection attempting. */
-template<typename T>
-const char  AutoConnectCore<T>::_PAGE_CONNECTING[] PROGMEM = {
-  "{{REQ}}"
-  "{{HEAD}}"
+template <typename T>
+const char AutoConnectCore<T>::_PAGE_CONNECTING[] PROGMEM = {
+    "{{REQ}}"
+    "{{HEAD}}"
     "<title>" AUTOCONNECT_PAGETITLE_CONNECTING "</title>"
     "<style type=\"text/css\">"
-      "{{CSS_BASE}}"
-      "{{CSS_SPINNER}}"
-      "{{CSS_LUXBAR}}"
+    "{{CSS_BASE}}"
+    "{{CSS_SPINNER}}"
+    "{{CSS_LUXBAR}}"
     "</style>"
-  "</head>"
-  "<body style=\"padding-top:58px;\">"
+    "</head>"
+    "<body style=\"padding-top:58px;\">"
     "<div class=\"container\">"
-      "{{MENU_PRE}}"
-      "{{MENU_POST}}"
-      "<div class=\"spinner\">"
-        "<div class=\"dbl-bounce1\"></div>"
-        "<div class=\"dbl-bounce2\"></div>"
-        "<div style=\"position:absolute;left:-100%;right:-100%;text-align:center;margin:10px auto;font-weight:bold;color:#0b0b33;\">{{CUR_SSID}}</div>"
-      "</div>"
+    "{{MENU_PRE}}"
+    "{{MENU_POST}}"
+    "<div class=\"spinner\">"
+    "<div class=\"dbl-bounce1\"></div>"
+    "<div class=\"dbl-bounce2\"></div>"
+    "<div style=\"position:absolute;left:-100%;right:-100%;text-align:center;margin:10px auto;font-weight:bold;color:#0b0b33;\">{{CUR_SSID}}</div>"
+    "</div>"
     "</div>"
     "<script type=\"text/javascript\">"
-      "setTimeout(\"link()\"," AUTOCONNECT_STRING_DEPLOY(AUTOCONNECT_RESPONSE_WAITTIME) ");"
-      "function link(){location.href='" AUTOCONNECT_URI_RESULT "';}"
-    "</script>"
-  "</body>"
-  "</html>"
-};
+    "setTimeout(\"link()\"," AUTOCONNECT_STRING_DEPLOY(AUTOCONNECT_RESPONSE_WAITTIME) ");"
+                                                                                      "function link(){location.href='" AUTOCONNECT_URI_RESULT "';}"
+                                                                                      "</script>"
+                                                                                      "</body>"
+                                                                                      "</html>"};
 
 /**< A page announcing that a connection has been established. */
-template<typename T>
-const char  AutoConnectCore<T>::_PAGE_SUCCESS[] PROGMEM = {
-  "{{HEAD}}"
+template <typename T>
+const char AutoConnectCore<T>::_PAGE_SUCCESS[] PROGMEM = {
+    "{{HEAD}}"
     "<title>" AUTOCONNECT_PAGETITLE_STATISTICS "</title>"
     "<style type=\"text/css\">"
-      "{{CSS_BASE}}"
-      "{{CSS_TABLE}}"
-      "{{CSS_LUXBAR}}"
+    "{{CSS_BASE}}"
+    "{{CSS_TABLE}}"
+    "{{CSS_LUXBAR}}"
     "</style>"
-  "</head>"
-  "<body style=\"padding-top:58px;\">"
+    "</head>"
+    "<body style=\"padding-top:58px;\">"
     "<div class=\"container\">"
-      "{{MENU_PRE}}"
-      "{{MENU_AUX}}"
-      "{{MENU_POST}}"
-      "<div>"
-        "<table class=\"info\" style=\"border:none;\">"
-          "<tbody>"
-          "<tr>"
-            "<td>" AUTOCONNECT_PAGESTATS_ESTABLISHEDCONNECTION "</td>"
-            "<td>{{ESTAB_SSID}}</td>"
-          "</tr>"
-          "<tr>"
-            "<td>" AUTOCONNECT_PAGESTATS_MODE "</td>"
-            "<td>{{WIFI_MODE}}({{WIFI_STATUS}})</td>"
-          "</tr>"
-          "<tr>"
-            "<td>" AUTOCONNECT_PAGESTATS_IP "</td>"
-            "<td>{{LOCAL_IP}}</td>"
-          "</tr>"
-            "<td>" AUTOCONNECT_PAGESTATS_GATEWAY "</td>"
-            "<td>{{GATEWAY}}</td>"
-          "</tr>"
-          "<tr>"
-            "<td>" AUTOCONNECT_PAGESTATS_SUBNETMASK "</td>"
-            "<td>{{NETMASK}}</td>"
-          "</tr>"
-          "<tr>"
-            "<td>" AUTOCONNECT_PAGESTATS_CHANNEL "</td>"
-            "<td>{{CHANNEL}}</td>"
-          "</tr>"
-          "<tr>"
-            "<td>" AUTOCONNECT_PAGESTATS_DBM "</td>"
-            "<td>{{DBM}}</td>"
-          "</tr>"
-          "</tbody>"
-        "</table>"
-      "</div>"
+    "{{MENU_PRE}}"
+    "{{MENU_AUX}}"
+    "{{MENU_POST}}"
+    "<div>"
+    "<table class=\"info\" style=\"border:none;\">"
+    "<tbody>"
+    "<tr>"
+    "<td>" AUTOCONNECT_PAGESTATS_ESTABLISHEDCONNECTION "</td>"
+    "<td>{{ESTAB_SSID}}</td>"
+    "</tr>"
+    "<tr>"
+    "<td>" AUTOCONNECT_PAGESTATS_MODE "</td>"
+    "<td>{{WIFI_MODE}}({{WIFI_STATUS}})</td>"
+    "</tr>"
+    "<tr>"
+    "<td>" AUTOCONNECT_PAGESTATS_IP "</td>"
+    "<td>{{LOCAL_IP}}</td>"
+    "</tr>"
+    "<td>" AUTOCONNECT_PAGESTATS_GATEWAY "</td>"
+    "<td>{{GATEWAY}}</td>"
+    "</tr>"
+    "<tr>"
+    "<td>" AUTOCONNECT_PAGESTATS_SUBNETMASK "</td>"
+    "<td>{{NETMASK}}</td>"
+    "</tr>"
+    "<tr>"
+    "<td>" AUTOCONNECT_PAGESTATS_CHANNEL "</td>"
+    "<td>{{CHANNEL}}</td>"
+    "</tr>"
+    "<tr>"
+    "<td>" AUTOCONNECT_PAGESTATS_DBM "</td>"
+    "<td>{{DBM}}</td>"
+    "</tr>"
+    "</tbody>"
+    "</table>"
     "</div>"
-  "</body>"
-  "</html>"
-};
+    "</div>"
+    "</body>"
+    "</html>"};
 
 /**< A response page for connection failed. */
-template<typename T>
-const char  AutoConnectCore<T>::_PAGE_FAIL[] PROGMEM = {
-  "{{HEAD}}"
+template <typename T>
+const char AutoConnectCore<T>::_PAGE_FAIL[] PROGMEM = {
+    "{{HEAD}}"
     "<title>" AUTOCONNECT_PAGETITLE_CONNECTIONFAILED "</title>"
     "<style type=\"text/css\">"
-      "{{CSS_BASE}}"
-      "{{CSS_TABLE}}"
-      "{{CSS_LUXBAR}}"
+    "{{CSS_BASE}}"
+    "{{CSS_TABLE}}"
+    "{{CSS_LUXBAR}}"
     "</style>"
-  "</head>"
-  "<body style=\"padding-top:58px;\">"
+    "</head>"
+    "<body style=\"padding-top:58px;\">"
     "<div class=\"container\">"
-      "{{MENU_PRE}}"
-      "{{MENU_AUX}}"
-      "{{MENU_POST}}"
-      "<div>"
-        "<table class=\"info\" style=\"border:none;\">"
-          "<tbody>"
-          "<tr>"
-            "<td>" AUTOCONNECT_PAGECONNECTIONFAILED_CONNECTIONFAILED "</td>"
-            "<td>{{STATION_STATUS}}</td>"
-          "</tr>"
-          "</tbody>"
-        "</table>"
-      "</div>"
+    "{{MENU_PRE}}"
+    "{{MENU_AUX}}"
+    "{{MENU_POST}}"
+    "<div>"
+    "<table class=\"info\" style=\"border:none;\">"
+    "<tbody>"
+    "<tr>"
+    "<td>" AUTOCONNECT_PAGECONNECTIONFAILED_CONNECTIONFAILED "</td>"
+    "<td>{{STATION_STATUS}}</td>"
+    "</tr>"
+    "</tbody>"
+    "</table>"
     "</div>"
-  "</body>"
-  "</html>"
-};
+    "</div>"
+    "</body>"
+    "</html>"};
 
 /**< A response page for disconnected from the AP. */
-template<typename T>
-const char  AutoConnectCore<T>::_PAGE_DISCONN[] PROGMEM = {
-  "{{DISCONNECT}}"
-  "{{HEAD}}"
+template <typename T>
+const char AutoConnectCore<T>::_PAGE_DISCONN[] PROGMEM = {
+    "{{DISCONNECT}}"
+    "{{HEAD}}"
     "<title>" AUTOCONNECT_PAGETITLE_DISCONNECTED "</title>"
     "<style type=\"text/css\">"
-      "{{CSS_BASE}}"
-      "{{CSS_LUXBAR}}"
+    "{{CSS_BASE}}"
+    "{{CSS_LUXBAR}}"
     "</style>"
-  "</head>"
-  "<body style=\"padding-top:58px;\">"
+    "</head>"
+    "<body style=\"padding-top:58px;\">"
     "<div class=\"container\">"
-      "{{MENU_PRE}}"
-      "{{MENU_POST}}"
+    "{{MENU_PRE}}"
+    "{{MENU_POST}}"
     "</div>"
-  "</body>"
-  "</html>"
-};
+    "</body>"
+    "</html>"};
 
-template<typename T>
-uint32_t AutoConnectCore<T>::_getChipId() {
+template <typename T>
+uint32_t AutoConnectCore<T>::_getChipId()
+{
 #if defined(ARDUINO_ARCH_ESP8266)
   return ESP.getChipId();
 #elif defined(ARDUINO_ARCH_ESP32)
-  uint64_t  chipId;
+  uint64_t chipId;
   chipId = ESP.getEfuseMac();
   return (uint32_t)(chipId >> 32);
 #endif
 }
 
-template<typename T>
-uint32_t AutoConnectCore<T>::_getFlashChipRealSize() {
+template <typename T>
+uint32_t AutoConnectCore<T>::_getFlashChipRealSize()
+{
 #if defined(ARDUINO_ARCH_ESP8266)
   return ESP.getFlashChipRealSize();
 #elif defined(ARDUINO_ARCH_ESP32)
@@ -934,72 +920,111 @@ uint32_t AutoConnectCore<T>::_getFlashChipRealSize() {
 #endif
 }
 
-template<typename T>
-String AutoConnectCore<T>::_token_CSS_BASE(PageArgument& args) {
+template <typename T>
+String AutoConnectCore<T>::_getSystemUptime()
+{
+#if defined(ARDUINO_ARCH_ESP8266)
+  time_t millisecs = millis();
+#elif defined(ARDUINO_ARCH_ESP32)
+  time_t millisecs = esp_timer_get_time() / 1000;
+#endif
+  
+  int systemUpTimeM = int((millisecs / (1000 * 60)) % 60);
+  int systemUpTimeH = int((millisecs / (1000 * 60 * 60)) % 24);
+  int systemUpTimeD = int((millisecs / (1000 * 60 * 60 * 24)) % 365);
+  
+  String uptime = String(systemUpTimeM) + "m ";
+  if (systemUpTimeH > 0)
+  {
+    uptime += String(systemUpTimeH) + "h ";
+  }
+  if (systemUpTimeD > 0)
+  {
+    uptime += String(systemUpTimeD) + "d ";
+  }
+  return uptime;
+}
+
+
+
+
+template <typename T>
+String AutoConnectCore<T>::_token_CSS_BASE(PageArgument &args)
+{
   AC_UNUSED(args);
   return String(FPSTR(_CSS_BASE));
 }
 
-template<typename T>
-String AutoConnectCore<T>::_token_CSS_ICON_LOCK(PageArgument& args) {
+template <typename T>
+String AutoConnectCore<T>::_token_CSS_ICON_LOCK(PageArgument &args)
+{
   AC_UNUSED(args);
   return String(FPSTR(_CSS_ICON_LOCK));
 }
 
-template<typename T>
-String AutoConnectCore<T>::_token_CSS_ICON_TRASH(PageArgument& args) {
+template <typename T>
+String AutoConnectCore<T>::_token_CSS_ICON_TRASH(PageArgument &args)
+{
   AC_UNUSED(args);
   return (_apConfig.menuItems & AC_MENUITEM_DELETESSID) ? String(FPSTR(_CSS_ICON_TRASH)) : String("");
 }
 
-template<typename T>
-String AutoConnectCore<T>::_token_CSS_INPUT_BUTTON(PageArgument& args) {
+template <typename T>
+String AutoConnectCore<T>::_token_CSS_INPUT_BUTTON(PageArgument &args)
+{
   AC_UNUSED(args);
   return String(FPSTR(_CSS_INPUT_BUTTON));
 }
 
-template<typename T>
-String AutoConnectCore<T>::_token_CSS_INPUT_TEXT(PageArgument& args) {
+template <typename T>
+String AutoConnectCore<T>::_token_CSS_INPUT_TEXT(PageArgument &args)
+{
   AC_UNUSED(args);
   return String(FPSTR(_CSS_INPUT_TEXT));
 }
 
-template<typename T>
-String AutoConnectCore<T>::_token_CSS_LUXBAR(PageArgument& args) {
+template <typename T>
+String AutoConnectCore<T>::_token_CSS_LUXBAR(PageArgument &args)
+{
   AC_UNUSED(args);
   return String(FPSTR(_CSS_LUXBAR));
 }
 
-template<typename T>
-String AutoConnectCore<T>::_token_CSS_SPINNER(PageArgument& args) {
+template <typename T>
+String AutoConnectCore<T>::_token_CSS_SPINNER(PageArgument &args)
+{
   AC_UNUSED(args);
   return String(FPSTR(_CSS_SPINNER));
 }
 
-template<typename T>
-String AutoConnectCore<T>::_token_CSS_TABLE(PageArgument& args) {
+template <typename T>
+String AutoConnectCore<T>::_token_CSS_TABLE(PageArgument &args)
+{
   AC_UNUSED(args);
   return String(FPSTR(_CSS_TABLE));
 }
 
-template<typename T>
-String AutoConnectCore<T>::_token_CSS_UL(PageArgument& args) {
+template <typename T>
+String AutoConnectCore<T>::_token_CSS_UL(PageArgument &args)
+{
   AC_UNUSED(args);
   return String(FPSTR(_CSS_UL));
 }
 
-template<typename T>
-String AutoConnectCore<T>::_token_MENU_AUX(PageArgument& args) {
+template <typename T>
+String AutoConnectCore<T>::_token_MENU_AUX(PageArgument &args)
+{
   return _mold_MENU_AUX(args);
 }
 
-template<typename T>
-String AutoConnectCore<T>::_token_MENU_PRE(PageArgument& args) {
-  String  currentMenu = FPSTR(_ELM_MENU_PRE);
-  String  menuItem = _attachMenuItem(AC_MENUITEM_CONFIGNEW) +
-                     _attachMenuItem(AC_MENUITEM_OPENSSIDS) +
-                     _attachMenuItem(AC_MENUITEM_DISCONNECT) +
-                     _attachMenuItem(AC_MENUITEM_RESET);
+template <typename T>
+String AutoConnectCore<T>::_token_MENU_PRE(PageArgument &args)
+{
+  String currentMenu = FPSTR(_ELM_MENU_PRE);
+  String menuItem = _attachMenuItem(AC_MENUITEM_CONFIGNEW) +
+                    _attachMenuItem(AC_MENUITEM_OPENSSIDS) +
+                    _attachMenuItem(AC_MENUITEM_DISCONNECT) +
+                    _attachMenuItem(AC_MENUITEM_RESET);
   currentMenu.replace(String(F("MENU_LIST")), menuItem);
   currentMenu.replace(String(F("BOOT_URI")), _getBootUri());
   currentMenu.replace(String(F("MENU_TITLE")), _menuTitle);
@@ -1007,65 +1032,72 @@ String AutoConnectCore<T>::_token_MENU_PRE(PageArgument& args) {
   return currentMenu;
 }
 
-template<typename T>
-String AutoConnectCore<T>::_token_MENU_POST(PageArgument& args) {
+template <typename T>
+String AutoConnectCore<T>::_token_MENU_POST(PageArgument &args)
+{
   AC_UNUSED(args);
-  String  postMenu = FPSTR(_ELM_MENU_POST);
+  String postMenu = FPSTR(_ELM_MENU_POST);
   postMenu.replace(String(F("MENU_HOME")), _attachMenuItem(AC_MENUITEM_HOME));
   postMenu.replace(String(F("HOME_URI")), _apConfig.homeUri);
   postMenu.replace(String(F("MENU_DEVINFO")), _attachMenuItem(AC_MENUITEM_DEVINFO));
   return postMenu;
 }
 
-template<typename T>
-String AutoConnectCore<T>::_token_AP_MAC(PageArgument& args) {
+template <typename T>
+String AutoConnectCore<T>::_token_AP_MAC(PageArgument &args)
+{
   AC_UNUSED(args);
   uint8_t macAddress[6];
   WiFi.softAPmacAddress(macAddress);
   return AutoConnectCore<T>::_toMACAddressString(macAddress);
 }
 
-template<typename T>
-String AutoConnectCore<T>::_token_BOOTURI(PageArgument& args) {
+template <typename T>
+String AutoConnectCore<T>::_token_BOOTURI(PageArgument &args)
+{
   AC_UNUSED(args);
   return _getBootUri();
 }
 
-template<typename T>
-String AutoConnectCore<T>::_token_CHANNEL(PageArgument& args) {
+template <typename T>
+String AutoConnectCore<T>::_token_CHANNEL(PageArgument &args)
+{
   AC_UNUSED(args);
   return String(WiFi.channel());
 }
 
-template<typename T>
-String AutoConnectCore<T>::_token_CHIP_ID(PageArgument& args) {
+template <typename T>
+String AutoConnectCore<T>::_token_CHIP_ID(PageArgument &args)
+{
   AC_UNUSED(args);
   return String(_getChipId());
 }
 
-template<typename T>
-String AutoConnectCore<T>::_token_CONFIG_STAIP(PageArgument& args) {
+template <typename T>
+String AutoConnectCore<T>::_token_CONFIG_STAIP(PageArgument &args)
+{
   AC_UNUSED(args);
   static const char _configIPList[] PROGMEM =
-    "<li class=\"exp\">"
-    "<label for=\"%s\">%s</label>"
-    "<input id=\"%s\" type=\"text\" name=\"%s\" value=\"%s\">"
-    "</li>";
-  struct _reps {
+      "<li class=\"exp\">"
+      "<label for=\"%s\">%s</label>"
+      "<input id=\"%s\" type=\"text\" name=\"%s\" value=\"%s\">"
+      "</li>";
+  struct _reps
+  {
     PGM_P lid;
     PGM_P lbl;
-  } static const reps[]  = {
-    { PSTR(AUTOCONNECT_PARAMID_STAIP), PSTR(AUTOCONNECT_PAGECONFIG_IPADDRESS) },
-    { PSTR(AUTOCONNECT_PARAMID_GTWAY), PSTR(AUTOCONNECT_PAGECONFIG_GATEWAY) },
-    { PSTR(AUTOCONNECT_PARAMID_NTMSK), PSTR(AUTOCONNECT_PAGECONFIG_NETMASK) },
-    { PSTR(AUTOCONNECT_PARAMID_DNS1), PSTR(AUTOCONNECT_PAGECONFIG_DNS1) },
-    { PSTR(AUTOCONNECT_PARAMID_DNS2), PSTR(AUTOCONNECT_PAGECONFIG_DNS2) }
-  };
-  char  liCont[600];
-  char* liBuf = liCont;
+  } static const reps[] = {
+      {PSTR(AUTOCONNECT_PARAMID_STAIP), PSTR(AUTOCONNECT_PAGECONFIG_IPADDRESS)},
+      {PSTR(AUTOCONNECT_PARAMID_GTWAY), PSTR(AUTOCONNECT_PAGECONFIG_GATEWAY)},
+      {PSTR(AUTOCONNECT_PARAMID_NTMSK), PSTR(AUTOCONNECT_PAGECONFIG_NETMASK)},
+      {PSTR(AUTOCONNECT_PARAMID_DNS1), PSTR(AUTOCONNECT_PAGECONFIG_DNS1)},
+      {PSTR(AUTOCONNECT_PARAMID_DNS2), PSTR(AUTOCONNECT_PAGECONFIG_DNS2)}};
+  char liCont[600];
+  char *liBuf = liCont;
 
-  for (uint8_t i = 0; i < 5; i++) {
-    IPAddress*  ip = nullptr;
+  for (uint8_t i = 0; i < 5; i++)
+  {
+    IPAddress *ip = nullptr;
     if (i == 0)
       ip = &_apConfig.staip;
     else if (i == 1)
@@ -1076,74 +1108,91 @@ String AutoConnectCore<T>::_token_CONFIG_STAIP(PageArgument& args) {
       ip = &_apConfig.dns1;
     else if (i == 4)
       ip = &_apConfig.dns2;
-    String  ipStr = ip != nullptr ? ip->toString() : String(F("0.0.0.0"));
+    String ipStr = ip != nullptr ? ip->toString() : String(F("0.0.0.0"));
     snprintf_P(liBuf, sizeof(liCont) - (liBuf - liCont), (PGM_P)_configIPList, reps[i].lid, reps[i].lbl, reps[i].lid, reps[i].lid, ipStr.c_str());
     liBuf += strlen(liBuf);
   }
   return String(liCont);
 }
 
-template<typename T>
-String AutoConnectCore<T>::_token_CPU_FREQ(PageArgument& args) {
+template <typename T>
+String AutoConnectCore<T>::_token_CPU_FREQ(PageArgument &args)
+{
   AC_UNUSED(args);
   return String(ESP.getCpuFreqMHz());
 }
 
-template<typename T>
-String AutoConnectCore<T>::_token_CURRENT_SSID(PageArgument& args) {
+template <typename T>
+String AutoConnectCore<T>::_token_CURRENT_SSID(PageArgument &args)
+{
   AC_UNUSED(args);
-  char  ssid_c[sizeof(station_config_t::ssid) + 1];
+  char ssid_c[sizeof(station_config_t::ssid) + 1];
   *ssid_c = '\0';
-  strncat(ssid_c, reinterpret_cast<char*>(_credential.ssid), sizeof(ssid_c) - 1);
-  String  ssid = String(ssid_c);
+  strncat(ssid_c, reinterpret_cast<char *>(_credential.ssid), sizeof(ssid_c) - 1);
+  String ssid = String(ssid_c);
   return ssid;
 }
 
-template<typename T>
-String AutoConnectCore<T>::_token_DBM(PageArgument& args) {
+template <typename T>
+String AutoConnectCore<T>::_token_DBM(PageArgument &args)
+{
   AC_UNUSED(args);
   int32_t dBm = WiFi.RSSI();
   return (dBm == 31 ? String(F("N/A")) : String(dBm));
 }
 
-template<typename T>
-String AutoConnectCore<T>::_token_ESTAB_SSID(PageArgument& args) {
+template <typename T>
+String AutoConnectCore<T>::_token_ESTAB_SSID(PageArgument &args)
+{
   AC_UNUSED(args);
   return (WiFi.status() == WL_CONNECTED ? WiFi.SSID() : String(F("N/A")));
 }
 
-template<typename T>
-String AutoConnectCore<T>::_token_FLASH_SIZE(PageArgument& args) {
+template <typename T>
+String AutoConnectCore<T>::_token_FLASH_SIZE(PageArgument &args)
+{
   AC_UNUSED(args);
   return String(_getFlashChipRealSize());
 }
 
-template<typename T>
-String AutoConnectCore<T>::_token_FREE_HEAP(PageArgument& args) {
+template <typename T>
+String AutoConnectCore<T>::_token_FREE_HEAP(PageArgument &args)
+{
   AC_UNUSED(args);
   return String(_freeHeapSize);
 }
 
-template<typename T>
-String AutoConnectCore<T>::_token_GATEWAY(PageArgument& args) {
+template <typename T>
+String AutoConnectCore<T>::_token_SYSTEM_UPTIME(PageArgument &args)
+{
+  AC_UNUSED(args);
+  return _getSystemUptime();
+}
+
+template <typename T>
+String AutoConnectCore<T>::_token_GATEWAY(PageArgument &args)
+{
   AC_UNUSED(args);
   return WiFi.gatewayIP().toString();
 }
 
-template<typename T>
-String AutoConnectCore<T>::_token_HEAD(PageArgument& args) {
+template <typename T>
+String AutoConnectCore<T>::_token_HEAD(PageArgument &args)
+{
   AC_UNUSED(args);
   return String(FPSTR(_ELM_HTML_HEAD));
 }
 
-template<typename T>
-String AutoConnectCore<T>::_token_HIDDEN_COUNT(PageArgument& args) {
+template <typename T>
+String AutoConnectCore<T>::_token_HIDDEN_COUNT(PageArgument &args)
+{
   AC_UNUSED(args);
   return String(_hiddenSSIDCount);
 }
 
-template<typename T>
-String AutoConnectCore<T>::_token_LIST_SSID(PageArgument& args) {
+template <typename T>
+String AutoConnectCore<T>::_token_LIST_SSID(PageArgument &args)
+{
   // Obtain the page number to display.
   // When the display request is the first page, it will be obtained
   // from the scan results of the WiFiScan class if it has already been
@@ -1151,17 +1200,19 @@ String AutoConnectCore<T>::_token_LIST_SSID(PageArgument& args) {
   uint8_t page = 0;
   if (args.hasArg(String(F("page"))))
     page = args.arg("page").toInt();
-  else {
+  else
+  {
     // Scan at a first time
     _scanCount = WiFi.scanNetworks(false, true);
     AC_DBG("%d network(s) found, ", (int)_scanCount);
   }
   // Prepare SSID list content building buffer
-  size_t  bufSize = sizeof('\0') + 192 * (_scanCount > AUTOCONNECT_SSIDPAGEUNIT_LINES ? AUTOCONNECT_SSIDPAGEUNIT_LINES : _scanCount);
+  size_t bufSize = sizeof('\0') + 192 * (_scanCount > AUTOCONNECT_SSIDPAGEUNIT_LINES ? AUTOCONNECT_SSIDPAGEUNIT_LINES : _scanCount);
   bufSize += 88 * (_scanCount > AUTOCONNECT_SSIDPAGEUNIT_LINES ? (_scanCount > (AUTOCONNECT_SSIDPAGEUNIT_LINES * 2) ? 2 : 1) : 0);
   AC_DBG_DUMB("%d buf", bufSize);
-  char* ssidList = (char*)malloc(bufSize);
-  if (!ssidList) {
+  char *ssidList = (char *)malloc(bufSize);
+  if (!ssidList)
+  {
     AC_DBG_DUMB(" alloc. failed\n");
     WiFi.scanDelete();
     return _emptyString;
@@ -1169,25 +1220,29 @@ String AutoConnectCore<T>::_token_LIST_SSID(PageArgument& args) {
   AC_DBG_DUMB("\n");
   // Locate to the page and build SSD list content.
   static const char _ssidList[] PROGMEM =
-    "<input type=\"button\" onClick=\"onFocus(this.getAttribute('value'))\" value=\"%s\">"
-    "<label class=\"slist\">%d&#037;&ensp;Ch.%d</label>%s<br>";
+      "<input type=\"button\" onClick=\"onFocus(this.getAttribute('value'))\" value=\"%s\">"
+      "<label class=\"slist\">%d&#037;&ensp;Ch.%d</label>%s<br>";
   static const char _ssidEnc[] PROGMEM =
-    "<span class=\"img-lock\"></span>";
+      "<span class=\"img-lock\"></span>";
   static const char _ssidPage[] PROGMEM =
-    "<button type=\"submit\" name=\"page\" value=\"%d\" formaction=\"" AUTOCONNECT_URI_CONFIG "\">%s</button>&emsp;";
+      "<button type=\"submit\" name=\"page\" value=\"%d\" formaction=\"" AUTOCONNECT_URI_CONFIG "\">%s</button>&emsp;";
   _hiddenSSIDCount = 0;
   uint8_t validCount = 0;
   uint8_t dispCount = 0;
-  char* slBuf = ssidList;
+  char *slBuf = ssidList;
   *slBuf = '\0';
-  for (uint8_t i = 0; i < _scanCount; i++) {
+  for (uint8_t i = 0; i < _scanCount; i++)
+  {
     String ssid = WiFi.SSID(i);
-    if (ssid.length() > 0) {
+    if (ssid.length() > 0)
+    {
       // An available SSID may be listed.
       // AUTOCONNECT_SSIDPAGEUNIT_LINES determines the number of lines
       // per page in the available SSID list.
-      if (validCount >= page * AUTOCONNECT_SSIDPAGEUNIT_LINES && validCount <= (page + 1) * AUTOCONNECT_SSIDPAGEUNIT_LINES - 1) {
-        if (++dispCount <= AUTOCONNECT_SSIDPAGEUNIT_LINES) {
+      if (validCount >= page * AUTOCONNECT_SSIDPAGEUNIT_LINES && validCount <= (page + 1) * AUTOCONNECT_SSIDPAGEUNIT_LINES - 1)
+      {
+        if (++dispCount <= AUTOCONNECT_SSIDPAGEUNIT_LINES)
+        {
           snprintf_P(slBuf, bufSize - (slBuf - ssidList), (PGM_P)_ssidList, ssid.c_str(), AutoConnectCore<T>::_toWiFiQuality((int32_t)WiFi.RSSI(i)), WiFi.channel(i), WiFi.encryptionType(i) != ENC_TYPE_NONE ? (PGM_P)_ssidEnc : "");
           slBuf += strlen(slBuf);
         }
@@ -1200,12 +1255,14 @@ String AutoConnectCore<T>::_token_LIST_SSID(PageArgument& args) {
       _hiddenSSIDCount++;
   }
   // Prepare perv. button
-  if (page >= 1) {
+  if (page >= 1)
+  {
     snprintf_P(slBuf, bufSize - (slBuf - ssidList), (PGM_P)_ssidPage, page - 1, PSTR("Prev."));
     slBuf = ssidList + strlen(ssidList);
   }
   // Prepare next button
-  if (validCount > (page + 1) * AUTOCONNECT_SSIDPAGEUNIT_LINES) {
+  if (validCount > (page + 1) * AUTOCONNECT_SSIDPAGEUNIT_LINES)
+  {
     snprintf_P(slBuf, bufSize - (slBuf - ssidList), (PGM_P)_ssidPage, page + 1, PSTR("Next"));
   }
   String ssidListStr = String(ssidList);
@@ -1213,37 +1270,41 @@ String AutoConnectCore<T>::_token_LIST_SSID(PageArgument& args) {
   return ssidListStr;
 }
 
-template<typename T>
-String AutoConnectCore<T>::_token_LOCAL_IP(PageArgument& args) {
+template <typename T>
+String AutoConnectCore<T>::_token_LOCAL_IP(PageArgument &args)
+{
   AC_UNUSED(args);
   return WiFi.localIP().toString();
 }
 
-template<typename T>
-String AutoConnectCore<T>::_token_NETMASK(PageArgument& args) {
+template <typename T>
+String AutoConnectCore<T>::_token_NETMASK(PageArgument &args)
+{
   AC_UNUSED(args);
   return WiFi.subnetMask().toString();
 }
 
-template<typename T>
-String AutoConnectCore<T>::_token_OPEN_SSID(PageArgument& args) {
+template <typename T>
+String AutoConnectCore<T>::_token_OPEN_SSID(PageArgument &args)
+{
   AC_UNUSED(args);
   static const char _ssidUndeleted[] PROGMEM = "<div style=\"color:red\">%s " AUTOCONNECT_TEXT_COULDNOTDELETED "</div>";
   static const char _ssidList[] PROGMEM = "<input id=\"sb\" type=\"submit\" name=\"%s\" value=\"%s\"><label class=\"slist\">%s</label>%s%s<br>";
   static const char _ssidRssi[] PROGMEM = "%d&#037;&ensp;Ch.%d";
-  static const char _ssidNA[]   PROGMEM = "N/A";
+  static const char _ssidNA[] PROGMEM = "N/A";
   static const char _ssidTrsh[] PROGMEM = "<a onclick=\"crdel('%s')\" class=\"img-trash\"></a>";
   static const char _ssidLock[] PROGMEM = "<span class=\"img-lock\"></span>";
   static const char _ssidNull[] PROGMEM = "";
   String ssidList;
-  station_config_t  entry;
-  char  rssiCont[32];
-  char  trash[80] = {'\0'};
-  char  slCont[sizeof(_ssidList) + sizeof(AUTOCONNECT_PARAMID_CRED) + sizeof(station_config_t::ssid) + sizeof(rssiCont) + sizeof(trash) + sizeof(_ssidLock)];
+  station_config_t entry;
+  char rssiCont[32];
+  char trash[80] = {'\0'};
+  char slCont[sizeof(_ssidList) + sizeof(AUTOCONNECT_PARAMID_CRED) + sizeof(station_config_t::ssid) + sizeof(rssiCont) + sizeof(trash) + sizeof(_ssidLock)];
   AutoConnectCredential credit(_apConfig.boundaryOffset);
 
-  if (_indelibleSSID.length()) {
-    char  indelible[82];
+  if (_indelibleSSID.length())
+  {
+    char indelible[82];
 
     snprintf_P(indelible, sizeof(indelible), _ssidUndeleted, _indelibleSSID.c_str());
     ssidList = String(indelible);
@@ -1256,14 +1317,17 @@ String AutoConnectCore<T>::_token_OPEN_SSID(PageArgument& args) {
   else
     ssidList += String(F("<p><b>" AUTOCONNECT_TEXT_NOSAVEDCREDENTIALS "</b></p>"));
 
-  for (uint8_t i = 0; i < creEntries; i++) {
+  for (uint8_t i = 0; i < creEntries; i++)
+  {
     rssiCont[0] = '\0';
     PGM_P rssiSym = _ssidNA;
     PGM_P ssidLock = _ssidNull;
     credit.load(i, &entry);
     AC_DBG("Credential #%d loaded\n", (int)i);
-    for (int8_t sc = 0; sc < (int8_t)_scanCount; sc++) {
-      if (_isValidAP(entry, sc)) {
+    for (int8_t sc = 0; sc < (int8_t)_scanCount; sc++)
+    {
+      if (_isValidAP(entry, sc))
+      {
         // The access point collation key is determined at compile time
         // according to the AUTOCONNECT_APKEY_SSID definition, which is
         // either BSSID or SSID.
@@ -1276,36 +1340,40 @@ String AutoConnectCore<T>::_token_OPEN_SSID(PageArgument& args) {
       }
     }
     if (_apConfig.menuItems & AC_MENUITEM_DELETESSID)
-      snprintf_P(trash, sizeof(trash), (PGM_P)_ssidTrsh, reinterpret_cast<char*>(entry.ssid));
+      snprintf_P(trash, sizeof(trash), (PGM_P)_ssidTrsh, reinterpret_cast<char *>(entry.ssid));
 
-    snprintf_P(slCont, sizeof(slCont), (PGM_P)_ssidList, AUTOCONNECT_PARAMID_CRED, reinterpret_cast<char*>(entry.ssid), rssiSym, trash, ssidLock);
+    snprintf_P(slCont, sizeof(slCont), (PGM_P)_ssidList, AUTOCONNECT_PARAMID_CRED, reinterpret_cast<char *>(entry.ssid), rssiSym, trash, ssidLock);
     ssidList += String(slCont);
   }
   return ssidList;
 }
 
-template<typename T>
-String AutoConnectCore<T>::_token_SOFTAP_IP(PageArgument& args) {
+template <typename T>
+String AutoConnectCore<T>::_token_SOFTAP_IP(PageArgument &args)
+{
   AC_UNUSED(args);
   return WiFi.softAPIP().toString();
 }
 
-template<typename T>
-String AutoConnectCore<T>::_token_SSID_COUNT(PageArgument& args) {
+template <typename T>
+String AutoConnectCore<T>::_token_SSID_COUNT(PageArgument &args)
+{
   AC_UNUSED(args);
   return String(_scanCount);
 }
 
-template<typename T>
-String AutoConnectCore<T>::_token_STA_MAC(PageArgument& args) {
+template <typename T>
+String AutoConnectCore<T>::_token_STA_MAC(PageArgument &args)
+{
   AC_UNUSED(args);
   uint8_t macAddress[6];
   WiFi.macAddress(macAddress);
   return AutoConnectCore<T>::_toMACAddressString(macAddress);
 }
 
-template<typename T>
-String AutoConnectCore<T>::_token_STATION_STATUS(PageArgument& args) {
+template <typename T>
+String AutoConnectCore<T>::_token_STATION_STATUS(PageArgument &args)
+{
   AC_UNUSED(args);
   PGM_P wlStatusSymbol = PSTR("");
   PGM_P wlStatusSymbols[] = {
@@ -1317,7 +1385,8 @@ String AutoConnectCore<T>::_token_STATION_STATUS(PageArgument& args) {
     PSTR("CONNECT_FAIL"),
     PSTR("GOT_IP")
   };
-  switch (wifi_station_get_connect_status()) {
+  switch (wifi_station_get_connect_status())
+  {
   case STATION_IDLE:
     wlStatusSymbol = wlStatusSymbols[0];
     break;
@@ -1346,7 +1415,8 @@ String AutoConnectCore<T>::_token_STATION_STATUS(PageArgument& args) {
     PSTR("DISCONNECTED"),
     PSTR("NO_SHIELD")
   };
-  switch (_rsConnect) {
+  switch (_rsConnect)
+  {
   case WL_IDLE_STATUS:
     wlStatusSymbol = wlStatusSymbols[0];
     break;
@@ -1376,17 +1446,20 @@ String AutoConnectCore<T>::_token_STATION_STATUS(PageArgument& args) {
   return String("(") + String(_rsConnect) + String(") ") + String(FPSTR(wlStatusSymbol));
 }
 
-template<typename T>
-String AutoConnectCore<T>::_token_UPTIME(PageArgument& args) {
+template <typename T>
+String AutoConnectCore<T>::_token_UPTIME(PageArgument &args)
+{
   AC_UNUSED(args);
   return String(_apConfig.uptime);
 }
 
-template<typename T>
-String AutoConnectCore<T>::_token_WIFI_MODE(PageArgument& args) {
+template <typename T>
+String AutoConnectCore<T>::_token_WIFI_MODE(PageArgument &args)
+{
   AC_UNUSED(args);
   PGM_P wifiMode;
-  switch (WiFi.getMode()) {
+  switch (WiFi.getMode())
+  {
   case WIFI_OFF:
     wifiMode = PSTR("OFF");
     break;
@@ -1410,8 +1483,9 @@ String AutoConnectCore<T>::_token_WIFI_MODE(PageArgument& args) {
   return String(FPSTR(wifiMode));
 }
 
-template<typename T>
-String AutoConnectCore<T>::_token_WIFI_STATUS(PageArgument& args) {
+template <typename T>
+String AutoConnectCore<T>::_token_WIFI_STATUS(PageArgument &args)
+{
   AC_UNUSED(args);
   return String(WiFi.status());
 }
@@ -1421,14 +1495,16 @@ String AutoConnectCore<T>::_token_WIFI_STATUS(PageArgument& args) {
  *  @param  item  An enumerated value for the generating item configured in AutoConnectConfig.
  *  @return HTML string of a li tag with the menu item.
  */
-template<typename T>
-String AutoConnectCore<T>::_attachMenuItem(const AC_MENUITEM_t item) {
-  static const char _liTempl[]  PROGMEM = "<li class=\"lb-item\"%s><a href=\"%s\">%s</a></li>";
+template <typename T>
+String AutoConnectCore<T>::_attachMenuItem(const AC_MENUITEM_t item)
+{
+  static const char _liTempl[] PROGMEM = "<li class=\"lb-item\"%s><a href=\"%s\">%s</a></li>";
   PGM_P id = PSTR("");
   PGM_P link;
   PGM_P label;
 
-  switch (static_cast<AC_MENUITEM_t>(_apConfig.menuItems & static_cast<uint16_t>(item))) {
+  switch (static_cast<AC_MENUITEM_t>(_apConfig.menuItems & static_cast<uint16_t>(item)))
+  {
   case AC_MENUITEM_CONFIGNEW:
     link = PSTR(AUTOCONNECT_URI_CONFIG);
     label = PSTR(AUTOCONNECT_MENULABEL_CONFIGNEW);
@@ -1460,7 +1536,7 @@ String AutoConnectCore<T>::_attachMenuItem(const AC_MENUITEM_t item) {
     label = nullptr;
     break;
   }
-  char  li[128] = { '\0' };
+  char li[128] = {'\0'};
   if (!!id && !!link && !!label)
     snprintf(li, sizeof(li), (PGM_P)_liTempl, id, link, label);
   return String(li);
@@ -1474,20 +1550,23 @@ String AutoConnectCore<T>::_attachMenuItem(const AC_MENUITEM_t item) {
  *  @retval true  A response page generated.
  *  @retval false Requested uri is not defined.
  */
-template<typename T>
-PageElement* AutoConnectCore<T>::_setupPage(String& uri) {
+template <typename T>
+PageElement *AutoConnectCore<T>::_setupPage(String &uri)
+{
   PageElement *elm = new PageElement();
-  bool  reqAuth = false;
+  bool reqAuth = false;
 
   // Restore menu title
   _menuTitle = _apConfig.title;
 
   // Build the elements of current requested page.
-  if (uri == String(AUTOCONNECT_URI)) {
+  if (uri == String(AUTOCONNECT_URI))
+  {
 
     // Setup /_ac
     reqAuth = true;
     _freeHeapSize = ESP.getFreeHeap();
+
     elm->setMold(FPSTR(_PAGE_STAT));
     elm->addToken(FPSTR("HEAD"), std::bind(&AutoConnectCore<T>::_token_HEAD, this, std::placeholders::_1));
     elm->addToken(FPSTR("CSS_BASE"), std::bind(&AutoConnectCore<T>::_token_CSS_BASE, this, std::placeholders::_1));
@@ -1511,8 +1590,10 @@ PageElement* AutoConnectCore<T>::_setupPage(String& uri) {
     elm->addToken(FPSTR("FLASH_SIZE"), std::bind(&AutoConnectCore<T>::_token_FLASH_SIZE, this, std::placeholders::_1));
     elm->addToken(FPSTR("CHIP_ID"), std::bind(&AutoConnectCore<T>::_token_CHIP_ID, this, std::placeholders::_1));
     elm->addToken(FPSTR("FREE_HEAP"), std::bind(&AutoConnectCore<T>::_token_FREE_HEAP, this, std::placeholders::_1));
+    elm->addToken(FPSTR("SYSTEM_UPTIME"), std::bind(&AutoConnectCore<T>::_token_SYSTEM_UPTIME, this, std::placeholders::_1));
   }
-  else if (uri == String(AUTOCONNECT_URI_CONFIG) && (_apConfig.menuItems & AC_MENUITEM_CONFIGNEW)) {
+  else if (uri == String(AUTOCONNECT_URI_CONFIG) && (_apConfig.menuItems & AC_MENUITEM_CONFIGNEW))
+  {
 
     // Setup /_ac/config
     reqAuth = true;
@@ -1532,7 +1613,8 @@ PageElement* AutoConnectCore<T>::_setupPage(String& uri) {
     elm->addToken(FPSTR("HIDDEN_COUNT"), std::bind(&AutoConnectCore<T>::_token_HIDDEN_COUNT, this, std::placeholders::_1));
     elm->addToken(FPSTR("CONFIG_IP"), std::bind(&AutoConnectCore<T>::_token_CONFIG_STAIP, this, std::placeholders::_1));
   }
-  else if (uri == String(AUTOCONNECT_URI_CONNECT) && (_apConfig.menuItems & AC_MENUITEM_CONFIGNEW || _apConfig.menuItems & AC_MENUITEM_OPENSSIDS)) {
+  else if (uri == String(AUTOCONNECT_URI_CONNECT) && (_apConfig.menuItems & AC_MENUITEM_CONFIGNEW || _apConfig.menuItems & AC_MENUITEM_OPENSSIDS))
+  {
 
     // Setup /_ac/connect
     reqAuth = true;
@@ -1547,7 +1629,8 @@ PageElement* AutoConnectCore<T>::_setupPage(String& uri) {
     elm->addToken(FPSTR("MENU_POST"), std::bind(&AutoConnectCore<T>::_token_MENU_POST, this, std::placeholders::_1));
     elm->addToken(FPSTR("CUR_SSID"), std::bind(&AutoConnectCore<T>::_token_CURRENT_SSID, this, std::placeholders::_1));
   }
-  else if (uri == String(AUTOCONNECT_URI_OPEN) && (_apConfig.menuItems & AC_MENUITEM_OPENSSIDS)) {
+  else if (uri == String(AUTOCONNECT_URI_OPEN) && (_apConfig.menuItems & AC_MENUITEM_OPENSSIDS))
+  {
 
     // Setup /_ac/open
     reqAuth = true;
@@ -1563,14 +1646,16 @@ PageElement* AutoConnectCore<T>::_setupPage(String& uri) {
     elm->addToken(FPSTR("MENU_POST"), std::bind(&AutoConnectCore<T>::_token_MENU_POST, this, std::placeholders::_1));
     elm->addToken(FPSTR("OPEN_SSID"), std::bind(&AutoConnectCore<T>::_token_OPEN_SSID, this, std::placeholders::_1));
   }
-  else if (uri == String(AUTOCONNECT_URI_DELETE) && (_apConfig.menuItems & AC_MENUITEM_OPENSSIDS) && (_apConfig.menuItems & AC_MENUITEM_DELETESSID)) {
-  
+  else if (uri == String(AUTOCONNECT_URI_DELETE) && (_apConfig.menuItems & AC_MENUITEM_OPENSSIDS) && (_apConfig.menuItems & AC_MENUITEM_DELETESSID))
+  {
+
     // Setup /_ac/del
     reqAuth = true;
     elm->setMold(FPSTR("{{DELREQ}}"));
     elm->addToken(FPSTR("DELREQ"), std::bind(&AutoConnectCore<T>::_promptDeleteCredential, this, std::placeholders::_1));
   }
-  else if (uri == String(AUTOCONNECT_URI_DISCON) && (_apConfig.menuItems & AC_MENUITEM_DISCONNECT)) {
+  else if (uri == String(AUTOCONNECT_URI_DISCON) && (_apConfig.menuItems & AC_MENUITEM_DISCONNECT))
+  {
 
     // Setup /_ac/disc
     _menuTitle = FPSTR(AUTOCONNECT_MENUTEXT_DISCONNECT);
@@ -1582,7 +1667,8 @@ PageElement* AutoConnectCore<T>::_setupPage(String& uri) {
     elm->addToken(FPSTR("MENU_PRE"), std::bind(&AutoConnectCore<T>::_token_MENU_PRE, this, std::placeholders::_1));
     elm->addToken(FPSTR("MENU_POST"), std::bind(&AutoConnectCore<T>::_token_MENU_POST, this, std::placeholders::_1));
   }
-  else if (uri == String(AUTOCONNECT_URI_RESET) && (_apConfig.menuItems & AC_MENUITEM_RESET)) {
+  else if (uri == String(AUTOCONNECT_URI_RESET) && (_apConfig.menuItems & AC_MENUITEM_RESET))
+  {
 
     // Setup /_ac/reset
     reqAuth = true;
@@ -1592,13 +1678,15 @@ PageElement* AutoConnectCore<T>::_setupPage(String& uri) {
     elm->addToken(FPSTR("UPTIME"), std::bind(&AutoConnectCore<T>::_token_UPTIME, this, std::placeholders::_1));
     elm->addToken(FPSTR("RESET"), std::bind(&AutoConnectCore<T>::_induceReset, this, std::placeholders::_1));
   }
-  else if (uri == String(AUTOCONNECT_URI_RESULT)) {
+  else if (uri == String(AUTOCONNECT_URI_RESULT))
+  {
 
     // Setup /_ac/result
     elm->setMold(FPSTR("{{RESULT}}"));
     elm->addToken(FPSTR("RESULT"), std::bind(&AutoConnectCore<T>::_invokeResult, this, std::placeholders::_1));
   }
-  else if (uri == String(AUTOCONNECT_URI_SUCCESS)) {
+  else if (uri == String(AUTOCONNECT_URI_SUCCESS))
+  {
 
     // Setup /_ac/success
     elm->setMold(FPSTR(_PAGE_SUCCESS));
@@ -1618,7 +1706,8 @@ PageElement* AutoConnectCore<T>::_setupPage(String& uri) {
     elm->addToken(FPSTR("CHANNEL"), std::bind(&AutoConnectCore<T>::_token_CHANNEL, this, std::placeholders::_1));
     elm->addToken(FPSTR("DBM"), std::bind(&AutoConnectCore<T>::_token_DBM, this, std::placeholders::_1));
   }
-  else if (uri == String(AUTOCONNECT_URI_FAIL)) {
+  else if (uri == String(AUTOCONNECT_URI_FAIL))
+  {
 
     // Setup /_ac/fail
     _menuTitle = FPSTR(AUTOCONNECT_MENUTEXT_FAILED);
@@ -1632,14 +1721,16 @@ PageElement* AutoConnectCore<T>::_setupPage(String& uri) {
     elm->addToken(FPSTR("MENU_POST"), std::bind(&AutoConnectCore<T>::_token_MENU_POST, this, std::placeholders::_1));
     elm->addToken(FPSTR("STATION_STATUS"), std::bind(&AutoConnectCore<T>::_token_STATION_STATUS, this, std::placeholders::_1));
   }
-  else {
+  else
+  {
     delete elm;
     elm = nullptr;
   }
 
   // Regiter authentication
   // Determine the necessity of authentication from the AutoConnectConfig settings
-  if (elm) {
+  if (elm)
+  {
     bool auth = (_apConfig.auth != AC_AUTH_NONE) &&
                 (_apConfig.authScope & AC_AUTHSCOPE_AC) &&
                 reqAuth;
@@ -1656,10 +1747,11 @@ PageElement* AutoConnectCore<T>::_setupPage(String& uri) {
  *  It determines to admit authentication in the captive portal state
  *  when the AP_AUTHSCOPE_WITHCP is enabled.
  *  @param allow  Indication of whether to authenticate with the page.
- */ 
-template<typename T>
-void AutoConnectCore<T>::_authentication(bool allow) {
-  HTTPAuthMethod  method = _apConfig.auth == AC_AUTH_BASIC ? HTTPAuthMethod::BASIC_AUTH : HTTPAuthMethod::DIGEST_AUTH;
+ */
+template <typename T>
+void AutoConnectCore<T>::_authentication(bool allow)
+{
+  HTTPAuthMethod method = _apConfig.auth == AC_AUTH_BASIC ? HTTPAuthMethod::BASIC_AUTH : HTTPAuthMethod::DIGEST_AUTH;
   _authentication(allow, method);
 }
 
@@ -1670,22 +1762,24 @@ void AutoConnectCore<T>::_authentication(bool allow) {
  *  It determines to admit authentication in the captive portal state
  *  when the AP_AUTHSCOPE_WITHCP is enabled.
  *  @param allow  Indication of whether to authenticate with the page.
- */ 
-template<typename T>
-void AutoConnectCore<T>::_authentication(bool allow, const HTTPAuthMethod method) {
-  const char* user = nullptr;
-  const char* password = nullptr;
-  String  fails;
+ */
+template <typename T>
+void AutoConnectCore<T>::_authentication(bool allow, const HTTPAuthMethod method)
+{
+  const char *user = nullptr;
+  const char *password = nullptr;
+  String fails;
 
   // Enable authentication by setting of AC_AUTHSCOPE_DISCONNECTED even if WiFi is not connected.
-  String  accUrl = _webServer->hostHeader();
+  String accUrl = _webServer->hostHeader();
 
   if (WiFi.status() != WL_CONNECTED)
     allow = _apConfig.authScope & AC_AUTHSCOPE_WITHCP;
   else if ((WiFi.getMode() & WIFI_AP) && ((accUrl == WiFi.softAPIP().toString()) || accUrl.endsWith(F(".local"))))
     allow = _apConfig.authScope & AC_AUTHSCOPE_WITHCP;
 
-  if (allow) {
+  if (allow)
+  {
     // Regiter authentication method
     user = _apConfig.username.length() ? _apConfig.username.c_str() : _apConfig.apid.c_str();
     password = _apConfig.password.length() ? _apConfig.password.c_str() : _apConfig.psk.c_str();

--- a/src/AutoConnectPageImpl.hpp
+++ b/src/AutoConnectPageImpl.hpp
@@ -12,8 +12,7 @@
 
 #if defined(ARDUINO_ARCH_ESP8266)
 #include <ESP8266WiFi.h>
-extern "C"
-{
+extern "C" {
 #include <user_interface.h>
 }
 #elif defined(ARDUINO_ARCH_ESP32)
@@ -23,55 +22,55 @@ extern "C"
 #endif
 
 /**< Basic CSS common to all pages */
-template <typename T>
+template<typename T>
 const char AutoConnectCore<T>::_CSS_BASE[] PROGMEM = {
-    "html{"
+  "html{"
     "font-family:Helvetica,Arial,sans-serif;"
     "font-size:16px;"
     "-ms-text-size-adjust:100%;"
     "-webkit-text-size-adjust:100%;"
     "-moz-osx-font-smoothing:grayscale;"
     "-webkit-font-smoothing:antialiased"
-    "}"
-    "body{"
+  "}"
+  "body{"
     "margin:0;"
     "padding:0"
-    "}"
-    ".base-panel{"
+  "}"
+  ".base-panel{"
     "margin:0 22px 0 22px"
-    "}"
-    ".base-panel * label :not(.bins){"
+  "}"
+  ".base-panel * label :not(.bins){"
     "display:inline-block;"
     "width:3.0em;"
     "text-align:right"
-    "}"
-    ".base-panel * .slist{"
+  "}"
+  ".base-panel * .slist{"
     "width:auto;"
     "font-size:0.9em;"
     "margin-left:10px;"
     "text-align:left"
-    "}"
-    "input{"
+  "}"
+  "input{"
     "-moz-appearance:none;"
     "-webkit-appearance:none;"
     "font-size:0.9em;"
     "margin:8px 0 auto"
-    "}"
-    ".lap{"
+  "}"
+  ".lap{"
     "visibility:collapse"
-    "}"
-    ".lap:target{"
+  "}"
+  ".lap:target{"
     "visibility:visible"
-    "}"
-    ".lap:target .overlap{"
+  "}"
+  ".lap:target .overlap{"
     "opacity:0.7;"
     "transition:0.3s"
-    "}"
-    ".lap:target .modal_button{"
+  "}"
+  ".lap:target .modal_button{"
     "opacity:1;"
     "transition:0.3s"
-    "}"
-    ".overlap{"
+  "}"
+  ".overlap{"
     "top:0;"
     "left:0;"
     "width:100%;"
@@ -80,8 +79,8 @@ const char AutoConnectCore<T>::_CSS_BASE[] PROGMEM = {
     "opacity:0;"
     "background:#000;"
     "z-index:1000"
-    "}"
-    ".modal_button{"
+  "}"
+  ".modal_button{"
     "border-radius:13px;"
     "background:#660033;"
     "color:#ffffcc;"
@@ -97,76 +96,80 @@ const char AutoConnectCore<T>::_CSS_BASE[] PROGMEM = {
     "position:fixed;"
     "opacity:0;"
     "z-index:1001"
-    "}"};
+  "}"
+};
 
 /**< non-marked list for UL */
-template <typename T>
+template<typename T>
 const char AutoConnectCore<T>::_CSS_UL[] PROGMEM = {
-    ".noorder,.exp{"
+  ".noorder,.exp{"
     "padding:0;"
     "list-style:none;"
     "display:table"
-    "}"
-    ".noorder li,.exp{"
+  "}"
+  ".noorder li,.exp{"
     "display:table-row-group"
-    "}"
-    ".noorder li label, .exp li{"
+  "}"
+  ".noorder li label, .exp li{"
     "display:table-cell;"
     "width:auto;"
     "text-align:right;"
     "padding:10px 0.5em"
-    "}"
-    ".noorder input[type=\"checkbox\"]{"
+  "}"
+  ".noorder input[type=\"checkbox\"]{"
     "-moz-appearance:checkbox;"
     "-webkit-appearance:checkbox"
-    "}"
-    ".noorder input[type=\"radio\"]{"
+  "}"
+  ".noorder input[type=\"radio\"]{"
     "cursor:pointer;"
     "-moz-appearance:radio;"
     "-webkit-appearance:radio"
-    "}"
-    ".noorder input[type=\"text\"],.noorder input[type=\"password\"],.noorder input[type=\"number\"],.noorder input[type=\"range\"]{"
+  "}"
+  ".noorder input[type=\"text\"],.noorder input[type=\"password\"],.noorder input[type=\"number\"],.noorder input[type=\"range\"]{"
     "width:auto"
-    "}"
-    ".noorder input[type=\"text\"]:invalid{"
+  "}"
+  ".noorder input[type=\"text\"]:invalid{"
     "background:#fce4d6"
-    "}"
-    ".noorder input[type=\"range\"]{"
+  "}"
+  ".noorder input[type=\"range\"]{"
     "height:7px;"
     "background:#dddddd;"
     "cursor:pointer"
-    "}"
-    ".magnify{"
+  "}"
+  ".magnify{"
     "display:inline-block"
-    "}"};
+  "}"
+};
 
 /**< Image icon for inline expansion, the lock mark. */
-template <typename T>
+template<typename T>
 const char AutoConnectCore<T>::_CSS_ICON_LOCK[] PROGMEM = {
-    ".img-lock{"
+  ".img-lock{"
     "width:22px;"
     "height:22px;"
     "margin-top:14px;"
     "float:right;"
     "background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAACXBIWXMAAAsTAAALEwEAmpwYAAAB1ElEQVRIibWVu0scURTGf3d2drBQFAWbbRQVCwuVLIZdi2gnWIiF/4GtKyuJGAJh8mgTcU0T8T8ICC6kiIVu44gvtFEQQWwsbExQJGHXmZtiZsOyzCN3Vz+4cDjfvec7j7l3QAF95onRZ54YKmdE1IbnS0c9mnAyAjkBxDy3LRHrjtRyu7OD52HntTAyvbw/HxP2hkCearrRb2WSCSuTTGi60S+QpzFhbwznDl/VVMHw0sF7hEjFbW2qkB38lfp8nNDipWcATil+uDM3cDWyeNRSijnfkHJnezb5Vkkgvbg3IOXD2e1ts93S+icnkZOAVaalZK3YQMa4L+pC6L1WduhYSeCf0PLBdxzOjZ93Lwvm6APAiLmlF1ubPiHotmaS41ExQjH0ZbfNM1NAFpgD0lVcICIrANqAVaAd+AFIYAy4BqaBG+Wsq5AH3vgk8xpYrzf4KLAZwhe8PYEIvQe4vc6H8Hnc2dQs0AFchvAXQGdEDF8s4A5TZS34BQqqQNaS1WMI3KD4WUbNoBJfce9CO7BSr4BfBe8A21vmUwh0VdjdTyHwscL+UK+AHxoD7FDoAX6/Cnpxn4ay/egCjcCL/w1chkqLakLQ/6ABhT57uAd+Vzv/Ara3iY6fK4WxAAAAAElFTkSuQmCC) no-repeat"
-    "}"};
+  "}"
+};
 
 /**< Image icon for inline expansion, the trash mark. */
-template <typename T>
+template<typename T>
 const char AutoConnectCore<T>::_CSS_ICON_TRASH[] PROGMEM = {
-    ".img-trash{"
+  ".img-trash{"
     "width:22px;"
     "height:22px;"
     "margin-top:14px;"
     "float:right;"
     "cursor:pointer;"
     "background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABYAAAAWCAYAAADEtGw7AAABhGlDQ1BJQ0MgcHJvZmlsZQAAKJF9kT1Iw0AcxV/TSkUqDnYQcQhSnSyIijpKFYtgobQVWnUwufQLmjQkKS6OgmvBwY/FqoOLs64OroIg+AHi6OSk6CIl/i8ptIjx4Lgf7+497t4BQqPCVDMwDqiaZaTiMTGbWxWDrxAQRAAzGJaYqSfSixl4jq97+Ph6F+VZ3uf+HL1K3mSATySeY7phEW8QT29aOud94jArSQrxOfGYQRckfuS67PIb56LDAs8MG5nUPHGYWCx2sNzBrGSoxFPEEUXVKF/Iuqxw3uKsVmqsdU/+wlBeW0lzneYQ4lhCAkmIkFFDGRVYiNKqkWIiRfsxD/+g40+SSyZXGYwcC6hCheT4wf/gd7dmYXLCTQrFgK4X2/4YAYK7QLNu29/Htt08AfzPwJXW9lcbwOwn6fW2FjkC+raBi+u2Ju8BlzvAwJMuGZIj+WkKhQLwfkbflAP6b4GeNbe31j5OH4AMdbV8AxwcAqNFyl73eHd3Z2//nmn19wONxHKyvZQ4mgAAAAZiS0dEAP8A/wD/oL2nkwAAAAlwSFlzAAAN1wAADdcBQiibeAAAALdJREFUOMvt1KEKAkEQBuBPMWkzWsRosWg2WEw2wTfQ6LNYfROLwSxWo81o02LQMsJxcJ4KguD9MOzMv8M/u8PsUqDAf2CMM25h5+CeopSzX8MBa6yCG2KAVhR5S3iDKuohsMcl9qpoR8FT8P20QCVDeIc5ljhm5DQwxeKdvnajn91ELOWnc146cbrIFr2Ik34myt8apUL4N4T3mMWa9J8ib9xG6OCKSXAPv/nJTUrxrG85tsn6Fu6nuijCLc4LEwAAAABJRU5ErkJggg==) no-repeat"
-    "}"};
+  "}"
+};
 
 /**< INPUT button and submit style */
-template <typename T>
+template<typename T>
 const char AutoConnectCore<T>::_CSS_INPUT_BUTTON[] PROGMEM = {
-    "input[type=\"button\"],input[type=\"submit\"],button[type=\"submit\"],button[type=\"button\"]{"
+  "input[type=\"button\"],input[type=\"submit\"],button[type=\"submit\"],button[type=\"button\"]{"
     "padding:8px 0.5em;"
     "font-weight:bold;"
     "letter-spacing:0.8px;"
@@ -175,46 +178,47 @@ const char AutoConnectCore<T>::_CSS_INPUT_BUTTON[] PROGMEM = {
     "border-radius:2px;"
     "margin-top:12px;"
     "cursor:pointer"
-    "}"
-    "input[type=\"button\"],button[type=\"button\"]{"
+  "}"
+  "input[type=\"button\"],button[type=\"button\"]{"
     "background-color:#1b5e20;"
     "border-color:#1b5e20;"
     "width:15em"
-    "}"
-    ".aux-page input[type=\"button\"],.aux-page button[type=\"button\"]{"
+  "}"
+  ".aux-page input[type=\"button\"],.aux-page button[type=\"button\"]{"
     "cursor:pointer;"
     "font-weight:normal;"
     "padding:8px 14px;"
     "margin:12px;"
     "width:auto"
-    "}"
-    "#sb[type=\"submit\"]{"
+  "}"
+  "#sb[type=\"submit\"]{"
     "padding:8px 0;"
     "width:13em"
-    "}"
-    "input[type=\"submit\"],button[type=\"submit\"]{"
+  "}"
+  "input[type=\"submit\"],button[type=\"submit\"]{"
     "padding:8px 30px;"
     "background-color:#006064;"
     "border-color:#006064"
-    "}"
-    "input[type=\"button\"],input[type=\"submit\"],button[type=\"submit\"]:focus,"
-    "input[type=\"button\"],input[type=\"submit\"],button[type=\"submit\"]:active{"
+  "}"
+  "input[type=\"button\"],input[type=\"submit\"],button[type=\"submit\"]:focus,"
+  "input[type=\"button\"],input[type=\"submit\"],button[type=\"submit\"]:active{"
     "outline:none;"
     "text-decoration:none"
-    "}"};
+  "}"
+};
 
 /**< INPUT text style */
-template <typename T>
+template<typename T>
 const char AutoConnectCore<T>::_CSS_INPUT_TEXT[] PROGMEM = {
-    "input[type=\"text\"],input[type=\"password\"],input[type=\"number\"],.aux-page select{"
+  "input[type=\"text\"],input[type=\"password\"],input[type=\"number\"],.aux-page select{"
     "background-color:#fff;"
     "border:1px solid #ccc;"
     "border-radius:2px;"
     "color:#444;"
     "margin:8px 0 8px 0;"
     "padding:10px"
-    "}"
-    "input[type=\"text\"],input[type=\"password\"],input[type=\"number\"]{"
+  "}"
+  "input[type=\"text\"],input[type=\"password\"],input[type=\"number\"]{"
     "font-weight:300;"
     "width:auto;"
     "-webkit-transition:all 0.20s ease-in;"
@@ -222,99 +226,101 @@ const char AutoConnectCore<T>::_CSS_INPUT_TEXT[] PROGMEM = {
     "-o-transition:all 0.20s ease-in;"
     "-ms-transition:all 0.20s ease-in;"
     "transition:all 0.20s ease-in"
-    "}"
-    "input[type=\"text\"]:focus,input[type=\"password\"]:focus,input[type=\"number\"]:focus{"
+  "}"
+  "input[type=\"text\"]:focus,input[type=\"password\"]:focus,input[type=\"number\"]:focus{"
     "outline:none;"
     "border-color:#5C9DED;"
     "box-shadow:0 0 3px #4B8CDC"
-    "}"
-    "input.error,input.error:focus{"
+  "}"
+  "input.error,input.error:focus{"
     "border-color:#ED5564;"
     "color:#D9434E;"
     "box-shadow:0 0 3px #D9434E"
-    "}"
-    "input:disabled{"
+  "}"
+  "input:disabled{"
     "opacity:0.6;"
     "background-color:#f7f7f7"
-    "}"
-    "input:disabled:hover{"
+  "}"
+  "input:disabled:hover{"
     "cursor:not-allowed"
-    "}"
-    "input.error::-webkit-input-placeholder,"
-    "input.error::-moz-placeholder,"
-    "input.error::-ms-input-placeholder{"
+  "}"
+  "input.error::-webkit-input-placeholder,"
+  "input.error::-moz-placeholder,"
+  "input.error::-ms-input-placeholder{"
     "color:#D9434E"
-    "}"
-    ".aux-page label{"
+  "}"
+  ".aux-page label{"
     "display:inline;"
     "padding:10px 0.5em;"
     "cursor:pointer"
-    "}"};
+  "}"
+};
 
 /**< TABLE style */
-template <typename T>
+template<typename T>
 const char AutoConnectCore<T>::_CSS_TABLE[] PROGMEM = {
-    "table{"
+  "table{"
     "border-collapse:collapse;"
     "border-spacing:0;"
     "border:1px solid #ddd;"
     "color:#444;"
     "background-color:#fff;"
     "margin-bottom:20px"
-    "}"
-    "table.info,"
-    "table.info>tfoot,"
-    "table.info>thead{"
+  "}"
+  "table.info,"
+  "table.info>tfoot,"
+  "table.info>thead{"
     "width:100%;"
     "border-color:#5C9DED"
-    "}"
-    "table.info>thead{"
+  "}"
+  "table.info>thead{"
     "background-color:#5C9DED"
-    "}"
-    "table.info>thead>tr>th{"
+  "}"
+  "table.info>thead>tr>th{"
     "color:#fff"
-    "}"
-    "td,"
-    "th{"
+  "}"
+  "td,"
+  "th{"
     "padding:10px 22px"
-    "}"
-    "thead{"
+  "}"
+  "thead{"
     "background-color:#f3f3f3;"
     "border-bottom:1px solid #ddd"
-    "}"
-    "thead>tr>th{"
+  "}"
+  "thead>tr>th{"
     "font-weight:400;"
     "text-align:left"
-    "}"
-    "tfoot{"
+  "}"
+  "tfoot{"
     "border-top:1px solid #ddd"
-    "}"
-    "tbody,"
-    "tbody>tr:nth-child(odd){"
+  "}"
+  "tbody,"
+  "tbody>tr:nth-child(odd){"
     "background-color:#fff"
-    "}"
-    "tbody>tr>td,"
-    "tfoot>tr>td{"
+  "}"
+  "tbody>tr>td,"
+  "tfoot>tr>td{"
     "font-weight:300;"
     "font-size:.88em"
-    "}"
-    "tbody>tr:nth-child(even){"
+  "}"
+  "tbody>tr:nth-child(even){"
     "background-color:#f7f7f7"
-    "}"
+  "}"
     "table.info tbody>tr:nth-child(even){"
     "background-color:#EFF5FD"
-    "}"};
+  "}"
+};
 
 /**< SVG animation for spinner */
-template <typename T>
+template<typename T>
 const char AutoConnectCore<T>::_CSS_SPINNER[] PROGMEM = {
-    ".spinner{"
+  ".spinner{"
     "width:40px;"
     "height:40px;"
     "position:relative;"
     "margin:100px auto"
-    "}"
-    ".dbl-bounce1, .dbl-bounce2{"
+  "}"
+  ".dbl-bounce1, .dbl-bounce2{"
     "width:100%;"
     "height:100%;"
     "border-radius:50%;"
@@ -325,130 +331,131 @@ const char AutoConnectCore<T>::_CSS_SPINNER[] PROGMEM = {
     "left:0;"
     "-webkit-animation:sk-bounce 2.0s infinite ease-in-out;"
     "animation:sk-bounce 2.0s infinite ease-in-out"
-    "}"
-    ".dbl-bounce2{"
+  "}"
+  ".dbl-bounce2{"
     "-webkit-animation-delay:-1.0s;"
     "animation-delay:-1.0s"
-    "}"
-    "@-webkit-keyframes sk-bounce{"
+  "}"
+  "@-webkit-keyframes sk-bounce{"
     "0%, 100%{-webkit-transform:scale(0.0)}"
     "50%{-webkit-transform:scale(1.0)}"
-    "}"
-    "@keyframes sk-bounce{"
+  "}"
+  "@keyframes sk-bounce{"
     "0%,100%{"
-    "transform:scale(0.0);"
-    "-webkit-transform:scale(0.0);"
+      "transform:scale(0.0);"
+      "-webkit-transform:scale(0.0);"
     "}50%{"
-    "transform:scale(1.0);"
-    "-webkit-transform:scale(1.0);"
+      "transform:scale(1.0);"
+      "-webkit-transform:scale(1.0);"
     "}"
-    "}"};
+  "}"
+};
 
 /**< Common menu bar. This style quotes LuxBar. */
 /**< balzss/luxbar is licensed under the MIT License https://github.com/balzss/luxbar */
-template <typename T>
+template<typename T>
 const char AutoConnectCore<T>::_CSS_LUXBAR[] PROGMEM = {
-    ".lb-fixed{"
+  ".lb-fixed{"
     "width:100%;"
     "position:fixed;"
     "top:0;"
     "left:0;"
     "z-index:1000;"
     "box-shadow:0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24)"
-    "}"
-    ".lb-burger span,"
-    ".lb-burger span::before,"
-    ".lb-burger span::after{"
+  "}"
+  ".lb-burger span,"
+  ".lb-burger span::before,"
+  ".lb-burger span::after{"
     "display:block;"
     "height:2px;"
     "width:26px;"
     "transition:0.6s ease"
-    "}"
-    ".lb-cb:checked~.lb-menu li .lb-burger span{"
+  "}"
+  ".lb-cb:checked~.lb-menu li .lb-burger span{"
     "background-color:transparent"
-    "}"
-    ".lb-cb:checked~.lb-menu li .lb-burger span::before,"
-    ".lb-cb:checked~.lb-menu li .lb-burger span::after{"
+  "}"
+  ".lb-cb:checked~.lb-menu li .lb-burger span::before,"
+  ".lb-cb:checked~.lb-menu li .lb-burger span::after{"
     "margin-top:0"
-    "}"
-    ".lb-header{"
+  "}"
+  ".lb-header{"
     "display:flex;"
     "flex-direction:row;"
     "justify-content:space-between;"
     "align-items:center;"
     "height:58px"
-    "}"
-    ".lb-menu-right .lb-burger{"
+  "}"
+  ".lb-menu-right .lb-burger{"
     "margin-left:auto"
-    "}"
-    ".lb-brand{"
+  "}"
+  ".lb-brand{"
     "font-size:1.6em;"
     "padding:18px 24px 18px 24px"
-    "}"
-    ".lb-menu{"
+  "}"
+  ".lb-menu{"
     "min-height:58px;"
     "transition:0.6s ease;"
     "width:100%"
-    "}"
-    ".lb-navigation{"
+  "}"
+  ".lb-navigation{"
     "display:flex;"
     "flex-direction:column;"
     "list-style:none;"
     "padding-left:0;"
     "margin:0"
-    "}"
-    ".lb-menu a,"
-    ".lb-item a{"
+  "}"
+  ".lb-menu a,"
+  ".lb-item a{"
     "text-decoration:none;"
     "color:inherit;"
     "cursor:pointer"
-    "}"
-    ".lb-item{"
+  "}"
+  ".lb-item{"
     "height:58px"
-    "}"
-    ".lb-item a{"
+  "}"
+  ".lb-item a{"
     "padding:18px 24px 18px 24px;"
     "display:block"
-    "}"
-    ".lb-burger{"
+  "}"
+  ".lb-burger{"
     "padding:18px 24px 18px 24px;"
     "position:relative;"
     "cursor:pointer"
-    "}"
-    ".lb-burger span::before,"
-    ".lb-burger span::after{"
+  "}"
+  ".lb-burger span::before,"
+  ".lb-burger span::after{"
     "content:'';"
     "position:absolute"
-    "}"
-    ".lb-burger span::before{"
+  "}"
+  ".lb-burger span::before{"
     "margin-top:-8px"
-    "}"
-    ".lb-burger span::after{"
+  "}"
+  ".lb-burger span::after{"
     "margin-top:8px"
-    "}"
-    ".lb-cb{"
+  "}"
+  ".lb-cb{"
     "display:none"
-    "}"
-    ".lb-cb:not(:checked)~.lb-menu{"
+  "}"
+  ".lb-cb:not(:checked)~.lb-menu{"
     "overflow:hidden;"
     "height:58px"
-    "}"
-    ".lb-cb:checked~.lb-menu{"
+  "}"
+  ".lb-cb:checked~.lb-menu{"
     "transition:height 0.6s ease;"
     "height:100vh;"
     "overflow:auto"
-    "}"
-    ".dropdown{"
+  "}"
+  ".dropdown{"
     "position:relative;"
     "height:auto;"
     "min-height:58px"
-    "}"
-    ".dropdown:hover>ul{"
+  "}"
+  ".dropdown:hover>ul{"
     "position:relative;"
     "display:block;"
     "min-width:100%"
-    "}"
-    ".dropdown>a::after{"
+  "}"
+  ".dropdown>a::after{"
     "position:absolute;"
     "content:'';"
     "right:10px;"
@@ -456,463 +463,474 @@ const char AutoConnectCore<T>::_CSS_LUXBAR[] PROGMEM = {
     "border-width:5px 5px 0;"
     "border-color:transparent;"
     "border-style:solid"
-    "}"
-    ".dropdown>ul{"
+  "}"
+  ".dropdown>ul{"
     "display:block;"
     "overflow-x:hidden;"
     "list-style:none;"
     "padding:0"
-    "}"
-    ".dropdown>ul .lb-item{"
+  "}"
+  ".dropdown>ul .lb-item{"
     "min-width:100%;"
     "height:29px;"
     "padding:5px 10px 5px 40px"
-    "}"
-    ".dropdown>ul .lb-item a{"
+  "}"
+  ".dropdown>ul .lb-item a{"
     "min-height:29px;"
     "line-height:29px;"
     "padding:0"
-    "}"
-    "@media screen and (min-width:768px){"
+  "}"
+  "@media screen and (min-width:768px){"
     ".lb-navigation{"
-    "flex-flow:row;"
-    "justify-content:flex-end;"
+      "flex-flow:row;"
+      "justify-content:flex-end;"
     "}"
     ".lb-burger{"
-    "display:none;"
+      "display:none;"
     "}"
     ".lb-cb:not(:checked)~.lb-menu{"
-    "overflow:visible;"
+      "overflow:visible;"
     "}"
     ".lb-cb:checked~.lb-menu{"
-    "height:58px;"
+      "height:58px;"
     "}"
     ".lb-menu .lb-item{"
-    "border-top:0;"
+      "border-top:0;"
     "}"
     ".lb-menu-right .lb-header{"
-    "margin-right:auto;"
+      "margin-right:auto;"
     "}"
     ".dropdown{"
-    "height:58px;"
+      "height:58px;"
     "}"
     ".dropdown:hover>ul{"
-    "position:absolute;"
-    "left:0;"
-    "top:58px;"
-    "padding:0;"
+      "position:absolute;"
+      "left:0;"
+      "top:58px;"
+      "padding:0;"
     "}"
     ".dropdown>ul{"
-    "display:none;"
+      "display:none;"
     "}"
     ".dropdown>ul .lb-item{"
-    "padding:5px 10px;"
+      "padding:5px 10px;"
     "}"
     ".dropdown>ul .lb-item a{"
-    "white-space:nowrap;"
+      "white-space:nowrap;"
     "}"
-    "}"
-    ".lb-cb:checked+.lb-menu .lb-burger-dblspin span::before{"
+  "}"
+  ".lb-cb:checked+.lb-menu .lb-burger-dblspin span::before{"
     "transform:rotate(225deg)"
-    "}"
-    ".lb-cb:checked+.lb-menu .lb-burger-dblspin span::after{"
+  "}"
+  ".lb-cb:checked+.lb-menu .lb-burger-dblspin span::after{"
     "transform:rotate(-225deg)"
-    "}"
-    ".lb-menu-material,"
-    ".lb-menu-material .dropdown ul{"
+  "}"
+  ".lb-menu-material,"
+  ".lb-menu-material .dropdown ul{"
     "background-color:" AUTOCONNECT_MENUCOLOR_BACKGROUND ";"
     "color:" AUTOCONNECT_MENUCOLOR_TEXT
-    "}"
-    ".lb-menu-material .active,"
-    ".lb-menu-material .lb-item:hover{"
+  "}"
+  ".lb-menu-material .active,"
+  ".lb-menu-material .lb-item:hover{"
     "background-color:" AUTOCONNECT_MENUCOLOR_ACTIVE
-    "}"
-    ".lb-menu-material .lb-burger span,"
-    ".lb-menu-material .lb-burger span::before,"
-    ".lb-menu-material .lb-burger span::after{"
+  "}"
+  ".lb-menu-material .lb-burger span,"
+  ".lb-menu-material .lb-burger span::before,"
+  ".lb-menu-material .lb-burger span::after{"
     "background-color:" AUTOCONNECT_MENUCOLOR_TEXT
-    "}"};
+  "}"
+};
 
 /**< Common html document header. */
-template <typename T>
+template<typename T>
 const char AutoConnectCore<T>::_ELM_HTML_HEAD[] PROGMEM = {
-    "<!DOCTYPE html>"
-    "<html>"
-    "<head>"
-    "<meta charset=\"UTF-8\" name=\"viewport\" content=\"width=device-width,initial-scale=1\">"};
+  "<!DOCTYPE html>"
+  "<html>"
+  "<head>"
+  "<meta charset=\"UTF-8\" name=\"viewport\" content=\"width=device-width,initial-scale=1\">"
+};
 
 /**< LuxBar menu element. */
-template <typename T>
-const char AutoConnectCore<T>::_ELM_MENU_PRE[] PROGMEM = {
-    "<header id=\"lb\" class=\"lb-fixed\">"
+template<typename T>
+const char  AutoConnectCore<T>::_ELM_MENU_PRE[] PROGMEM = {
+  "<header id=\"lb\" class=\"lb-fixed\">"
     "<input type=\"checkbox\" class=\"lb-cb\" id=\"lb-cb\"/>"
     "<div class=\"lb-menu lb-menu-right lb-menu-material\">"
-    "<ul class=\"lb-navigation\">"
-    "<li class=\"lb-header\">"
-    "<a href=\"BOOT_URI\" class=\"lb-brand\">MENU_TITLE</a>"
-    "<label class=\"lb-burger lb-burger-dblspin\" id=\"lb-burger\" for=\"lb-cb\"><span></span></label>"
-    "</li>"
-    "MENU_LIST"};
+      "<ul class=\"lb-navigation\">"
+        "<li class=\"lb-header\">"
+          "<a href=\"BOOT_URI\" class=\"lb-brand\">MENU_TITLE</a>"
+          "<label class=\"lb-burger lb-burger-dblspin\" id=\"lb-burger\" for=\"lb-cb\"><span></span></label>"
+        "</li>"
+        "MENU_LIST"
+};
 
-template <typename T>
-const char AutoConnectCore<T>::_ELM_MENU_POST[] PROGMEM = {
-    "MENU_HOME"
-    "MENU_DEVINFO"
-    "</ul>"
+template<typename T>
+const char  AutoConnectCore<T>::_ELM_MENU_POST[] PROGMEM = {
+        "MENU_HOME"
+        "MENU_DEVINFO"
+      "</ul>"
     "</div>"
     "<div class=\"lap\" id=\"rdlg\"><a href=\"#reset\" class=\"overlap\"></a>"
-    "<div class=\"modal_button\"><h2><a href=\"" AUTOCONNECT_URI_RESET "\" class=\"modal_button\">" AUTOCONNECT_BUTTONLABEL_RESET "</a></h2></div>"
+      "<div class=\"modal_button\"><h2><a href=\"" AUTOCONNECT_URI_RESET "\" class=\"modal_button\">" AUTOCONNECT_BUTTONLABEL_RESET "</a></h2></div>"
     "</div>"
-    "</header>"};
+  "</header>"
+};
 
 /**< The 404 page content. */
-template <typename T>
-const char AutoConnectCore<T>::_PAGE_404[] PROGMEM = {
-    "{{HEAD}}"
+template<typename T>
+const char  AutoConnectCore<T>::_PAGE_404[] PROGMEM = {
+  "{{HEAD}}"
     "<title>" AUTOCONNECT_PAGETITLE_NOTFOUND "</title>"
-    "</head>"
-    "<body>"
+  "</head>"
+  "<body>"
     "404 Not found"
-    "</body>"
-    "</html>"};
+  "</body>"
+  "</html>"
+};
 
 /**< The page that started the reset. */
-template <typename T>
-const char AutoConnectCore<T>::_PAGE_RESETTING[] PROGMEM = {
-    "{{HEAD}}"
+template<typename T>
+const char  AutoConnectCore<T>::_PAGE_RESETTING[] PROGMEM = {
+  "{{HEAD}}"
     "<meta http-equiv=\"refresh\" content=\"{{UPTIME}};url={{BOOTURI}}\">"
     "<title>" AUTOCONNECT_PAGETITLE_RESETTING "</title>"
-    "</head>"
-    "<body>"
+  "</head>"
+  "<body>"
     "<h3><div style=\"display:inline-block\"><span>{{RESET}}</span><span id=\"cd\"></span></div></h3>"
     "<script type=\"text/javascript\">"
-    "window.onload=function(){"
-    "var t={{UPTIME}},elm=document.getElementById(\"cd\"),ct=setInterval(function(){--t?elm.innerHTML=String(t)+\"&nbsp;sec.\":(elm.innerHTML=\"expiry\",clearInterval(ct))},1e3);"
-    "};"
+      "window.onload=function(){"
+        "var t={{UPTIME}},elm=document.getElementById(\"cd\"),ct=setInterval(function(){--t?elm.innerHTML=String(t)+\"&nbsp;sec.\":(elm.innerHTML=\"expiry\",clearInterval(ct))},1e3);"
+      "};"
     "</script>"
-    "</body>"
-    "</html>"};
+  "</body>"
+  "</html>"
+};
 
 /**< AutoConnect portal page. */
-template <typename T>
-const char AutoConnectCore<T>::_PAGE_STAT[] PROGMEM = {
-    "{{HEAD}}"
+template<typename T>
+const char  AutoConnectCore<T>::_PAGE_STAT[] PROGMEM = {
+  "{{HEAD}}"
     "<title>" AUTOCONNECT_PAGETITLE_STATISTICS "</title>"
     "<style type=\"text/css\">"
-    "{{CSS_BASE}}"
-    "{{CSS_TABLE}}"
-    "{{CSS_LUXBAR}}"
+      "{{CSS_BASE}}"
+      "{{CSS_TABLE}}"
+      "{{CSS_LUXBAR}}"
     "</style>"
-    "</head>"
-    "<body style=\"padding-top:58px;\">"
+  "</head>"
+  "<body style=\"padding-top:58px;\">"
     "<div class=\"container\">"
-    "{{MENU_PRE}}"
-    "{{MENU_AUX}}"
-    "{{MENU_POST}}"
-    "<div>"
-    "<table class=\"info\" style=\"border:none;\">"
-    "<tbody>"
-    "<tr>"
-    "<td>" AUTOCONNECT_PAGESTATS_ESTABLISHEDCONNECTION "</td>"
-    "<td>{{ESTAB_SSID}}</td>"
-    "</tr>"
-    "<tr>"
-    "<td>" AUTOCONNECT_PAGESTATS_MODE "</td>"
-    "<td>{{WIFI_MODE}}({{WIFI_STATUS}})</td>"
-    "</tr>"
-    "<tr>"
-    "<td>" AUTOCONNECT_PAGESTATS_IP "</td>"
-    "<td>{{LOCAL_IP}}</td>"
-    "</tr>"
-    "<tr>"
-    "<td>" AUTOCONNECT_PAGESTATS_GATEWAY "</td>"
-    "<td>{{GATEWAY}}</td>"
-    "</tr>"
-    "<tr>"
-    "<td>" AUTOCONNECT_PAGESTATS_SUBNETMASK "</td>"
-    "<td>{{NETMASK}}</td>"
-    "</tr>"
-    "<tr>"
-    "<td>" AUTOCONNECT_PAGESTATS_SOFTAPIP "</td>"
-    "<td>{{SOFTAP_IP}}</td>"
-    "</tr>"
-    "<tr>"
-    "<td>" AUTOCONNECT_PAGESTATS_APMAC "</td>"
-    "<td>{{AP_MAC}}</td>"
-    "</tr>"
-    "<tr>"
-    "<td>" AUTOCONNECT_PAGESTATS_STAMAC "</td>"
-    "<td>{{STA_MAC}}</td>"
-    "</tr>"
-    "<tr>"
-    "<td>" AUTOCONNECT_PAGESTATS_CHANNEL "</td>"
-    "<td>{{CHANNEL}}</td>"
-    "</tr>"
-    "<tr>"
-    "<td>" AUTOCONNECT_PAGESTATS_DBM "</td>"
-    "<td>{{DBM}}</td>"
-    "</tr>"
-    "<tr>"
-    "<td>" AUTOCONNECT_PAGESTATS_CHIPID "</td>"
-    "<td>{{CHIP_ID}}</td>"
-    "</tr>"
-    "<tr>"
-    "<td>" AUTOCONNECT_PAGESTATS_CPUFREQ "</td>"
-    "<td>{{CPU_FREQ}}MHz</td>"
-    "</tr>"
-    "<tr>"
-    "<td>" AUTOCONNECT_PAGESTATS_FLASHSIZE "</td>"
-    "<td>{{FLASH_SIZE}}</td>"
-    "</tr>"
-    "<tr>"
-    "<td>" AUTOCONNECT_PAGESTATS_FREEMEM "</td>"
-    "<td>{{FREE_HEAP}}</td>"
-    "</tr>"
-    "<tr>"
-    "<td>" AUTOCONNECT_PAGESTATS_SYSTEM_UPTIME "</td>"
-    "<td>{{SYSTEM_UPTIME}}</td>"
-    "</tr>"
-    "</tbody>"
-    "</table>"
+      "{{MENU_PRE}}"
+      "{{MENU_AUX}}"
+      "{{MENU_POST}}"
+      "<div>"
+        "<table class=\"info\" style=\"border:none;\">"
+          "<tbody>"
+          "<tr>"
+            "<td>" AUTOCONNECT_PAGESTATS_ESTABLISHEDCONNECTION "</td>"
+            "<td>{{ESTAB_SSID}}</td>"
+          "</tr>"
+          "<tr>"
+            "<td>" AUTOCONNECT_PAGESTATS_MODE "</td>"
+            "<td>{{WIFI_MODE}}({{WIFI_STATUS}})</td>"
+          "</tr>"
+          "<tr>"
+            "<td>" AUTOCONNECT_PAGESTATS_IP "</td>"
+            "<td>{{LOCAL_IP}}</td>"
+          "</tr>"
+          "<tr>"
+            "<td>" AUTOCONNECT_PAGESTATS_GATEWAY "</td>"
+            "<td>{{GATEWAY}}</td>"
+          "</tr>"
+          "<tr>"
+            "<td>" AUTOCONNECT_PAGESTATS_SUBNETMASK "</td>"
+            "<td>{{NETMASK}}</td>"
+          "</tr>"
+          "<tr>"
+            "<td>" AUTOCONNECT_PAGESTATS_SOFTAPIP "</td>"
+            "<td>{{SOFTAP_IP}}</td>"
+          "</tr>"
+          "<tr>"
+            "<td>" AUTOCONNECT_PAGESTATS_APMAC "</td>"
+            "<td>{{AP_MAC}}</td>"
+          "</tr>"
+          "<tr>"
+            "<td>" AUTOCONNECT_PAGESTATS_STAMAC "</td>"
+            "<td>{{STA_MAC}}</td>"
+          "</tr>"
+          "<tr>"
+            "<td>" AUTOCONNECT_PAGESTATS_CHANNEL "</td>"
+            "<td>{{CHANNEL}}</td>"
+          "</tr>"
+          "<tr>"
+            "<td>" AUTOCONNECT_PAGESTATS_DBM "</td>"
+            "<td>{{DBM}}</td>"
+          "</tr>"
+          "<tr>"
+            "<td>" AUTOCONNECT_PAGESTATS_CHIPID "</td>"
+            "<td>{{CHIP_ID}}</td>"
+          "</tr>"
+          "<tr>"
+            "<td>" AUTOCONNECT_PAGESTATS_CPUFREQ "</td>"
+            "<td>{{CPU_FREQ}}MHz</td>"
+          "</tr>"
+          "<tr>"
+            "<td>" AUTOCONNECT_PAGESTATS_FLASHSIZE "</td>"
+            "<td>{{FLASH_SIZE}}</td>"
+          "</tr>"
+          "<tr>"
+            "<td>" AUTOCONNECT_PAGESTATS_FREEMEM "</td>"
+            "<td>{{FREE_HEAP}}</td>"
+          "</tr>"
+          "<tr>"
+          "<td>" AUTOCONNECT_PAGESTATS_SYSTEM_UPTIME "</td>"
+          "<td>{{SYSTEM_UPTIME}}</td>"
+          "</tr>"
+          "</tbody>"
+        "</table>"
+      "</div>"
     "</div>"
-    "</div>"
-    "</body>"
-    "</html>"};
+  "</body>"
+  "</html>"
+};
 
 /**< A page that specifies the new configuration. */
-template <typename T>
-const char AutoConnectCore<T>::_PAGE_CONFIGNEW[] PROGMEM = {
-    "{{HEAD}}"
+template<typename T>
+const char  AutoConnectCore<T>::_PAGE_CONFIGNEW[] PROGMEM = {
+  "{{HEAD}}"
     "<title>" AUTOCONNECT_PAGETITLE_CONFIG "</title>"
     "<style type=\"text/css\">"
-    "{{CSS_BASE}}"
-    "{{CSS_ICON_LOCK}}"
-    "{{CSS_UL}}"
-    "{{CSS_INPUT_BUTTON}}"
-    "{{CSS_INPUT_TEXT}}"
-    "{{CSS_LUXBAR}}"
+      "{{CSS_BASE}}"
+      "{{CSS_ICON_LOCK}}"
+      "{{CSS_UL}}"
+      "{{CSS_INPUT_BUTTON}}"
+      "{{CSS_INPUT_TEXT}}"
+      "{{CSS_LUXBAR}}"
     "</style>"
-    "</head>"
-    "<body style=\"padding-top:58px;\">"
+  "</head>"
+  "<body style=\"padding-top:58px;\">"
     "<div class=\"container\">"
-    "{{MENU_PRE}}"
-    "{{MENU_AUX}}"
-    "{{MENU_POST}}"
-    "<div class=\"base-panel\">"
-    "<form action=\"" AUTOCONNECT_URI_CONNECT "\" method=\"post\">"
-    "<button style=\"width:0;height:0;padding:0;border:0;margin:0\" aria-hidden=\"true\" tabindex=\"-1\" type=\"submit\" name=\"apply\" value=\"apply\"></button>"
-    "{{LIST_SSID}}"
-    "<div style=\"margin:16px 0 8px 0;border-bottom:solid 1px #263238;\">" AUTOCONNECT_PAGECONFIG_TOTAL "{{SSID_COUNT}} " AUTOCONNECT_PAGECONFIG_HIDDEN "{{HIDDEN_COUNT}}</div>"
-    "<ul class=\"noorder\">"
-    "<li>"
-    "<label for=\"ssid\">" AUTOCONNECT_PAGECONFIG_SSID "</label>"
-    "<input id=\"ssid\" type=\"text\" name=\"" AUTOCONNECT_PARAMID_SSID "\" placeholder=\"" AUTOCONNECT_PAGECONFIG_SSID "\">"
-    "</li>"
-    "<li>"
-    "<label for=\"passphrase\">" AUTOCONNECT_PAGECONFIG_PASSPHRASE "</label>"
-    "<input id=\"passphrase\" type=\"password\" name=\"" AUTOCONNECT_PARAMID_PASS "\" placeholder=\"" AUTOCONNECT_PAGECONFIG_PASSPHRASE "\">"
-    "</li>"
-    "<li>"
-    "<label for=\"dhcp\">" AUTOCONNECT_PAGECONFIG_ENABLEDHCP "</label>"
-    "<input id=\"dhcp\" type=\"checkbox\" name=\"dhcp\" value=\"en\" checked onclick=\"vsw(this.checked);\">"
-    "</li>"
-    "{{CONFIG_IP}}"
-    "<li><input type=\"submit\" name=\"apply\" value=\"" AUTOCONNECT_PAGECONFIG_APPLY "\"></li>"
-    "</ul>"
-    "</form>"
+      "{{MENU_PRE}}"
+      "{{MENU_AUX}}"
+      "{{MENU_POST}}"
+      "<div class=\"base-panel\">"
+        "<form action=\"" AUTOCONNECT_URI_CONNECT "\" method=\"post\">"
+          "<button style=\"width:0;height:0;padding:0;border:0;margin:0\" aria-hidden=\"true\" tabindex=\"-1\" type=\"submit\" name=\"apply\" value=\"apply\"></button>"
+          "{{LIST_SSID}}"
+          "<div style=\"margin:16px 0 8px 0;border-bottom:solid 1px #263238;\">" AUTOCONNECT_PAGECONFIG_TOTAL "{{SSID_COUNT}} " AUTOCONNECT_PAGECONFIG_HIDDEN "{{HIDDEN_COUNT}}</div>"
+          "<ul class=\"noorder\">"
+            "<li>"
+              "<label for=\"ssid\">" AUTOCONNECT_PAGECONFIG_SSID "</label>"
+              "<input id=\"ssid\" type=\"text\" name=\"" AUTOCONNECT_PARAMID_SSID "\" placeholder=\"" AUTOCONNECT_PAGECONFIG_SSID "\">"
+            "</li>"
+            "<li>"
+              "<label for=\"passphrase\">" AUTOCONNECT_PAGECONFIG_PASSPHRASE "</label>"
+              "<input id=\"passphrase\" type=\"password\" name=\"" AUTOCONNECT_PARAMID_PASS "\" placeholder=\"" AUTOCONNECT_PAGECONFIG_PASSPHRASE "\">"
+            "</li>"
+            "<li>"
+              "<label for=\"dhcp\">" AUTOCONNECT_PAGECONFIG_ENABLEDHCP "</label>"
+              "<input id=\"dhcp\" type=\"checkbox\" name=\"dhcp\" value=\"en\" checked onclick=\"vsw(this.checked);\">"
+            "</li>"
+            "{{CONFIG_IP}}"
+            "<li><input type=\"submit\" name=\"apply\" value=\"" AUTOCONNECT_PAGECONFIG_APPLY "\"></li>"
+          "</ul>"
+        "</form>"
+      "</div>"
     "</div>"
-    "</div>"
-    "<script type=\"text/javascript\">"
+  "<script type=\"text/javascript\">"
     "window.onload=function(){"
-    "['" AUTOCONNECT_PARAMID_STAIP "','" AUTOCONNECT_PARAMID_GTWAY "','" AUTOCONNECT_PARAMID_NTMSK "','" AUTOCONNECT_PARAMID_DNS1 "','" AUTOCONNECT_PARAMID_DNS2 "'].forEach(function(n,o,t){"
-    "io=document.getElementById(n),io.placeholder='0.0.0.0',io.pattern='^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$'});"
-    "vsw(true)};"
+      "['" AUTOCONNECT_PARAMID_STAIP "','" AUTOCONNECT_PARAMID_GTWAY "','" AUTOCONNECT_PARAMID_NTMSK "','" AUTOCONNECT_PARAMID_DNS1 "','" AUTOCONNECT_PARAMID_DNS2 "'].forEach(function(n,o,t){"
+        "io=document.getElementById(n),io.placeholder='0.0.0.0',io.pattern='^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$'});"
+      "vsw(true)};"
     "function onFocus(e){"
-    "document.getElementById('ssid').value=e,document.getElementById('passphrase').focus()"
+      "document.getElementById('ssid').value=e,document.getElementById('passphrase').focus()"
     "}"
     "function vsw(e){"
-    "var t;t=e?'none':'table-row';for(const n of document.getElementsByClassName('exp'))n.style.display=t,n.getElementsByTagName('input')[0].disabled=e;e||document.getElementById('sip').focus()"
+      "var t;t=e?'none':'table-row';for(const n of document.getElementsByClassName('exp'))n.style.display=t,n.getElementsByTagName('input')[0].disabled=e;e||document.getElementById('sip').focus()"
     "}"
-    "</script>"
-    "</body>"
-    "</html>"};
+  "</script>"
+  "</body>"
+  "</html>"
+};
 
 /**< A page that reads stored authentication information and starts connection. */
-template <typename T>
-const char AutoConnectCore<T>::_PAGE_OPENCREDT[] PROGMEM = {
-    "{{HEAD}}"
+template<typename T>
+const char  AutoConnectCore<T>::_PAGE_OPENCREDT[] PROGMEM = {
+  "{{HEAD}}"
     "<title>" AUTOCONNECT_PAGETITLE_CREDENTIALS "</title>"
     "<style type=\"text/css\">"
-    "{{CSS_BASE}}"
-    "{{CSS_ICON_LOCK}}"
-    "{{CSS_ICON_TRASH}}"
-    "{{CSS_INPUT_BUTTON}}"
-    "{{CSS_LUXBAR}}"
+      "{{CSS_BASE}}"
+      "{{CSS_ICON_LOCK}}"
+      "{{CSS_ICON_TRASH}}"
+      "{{CSS_INPUT_BUTTON}}"
+      "{{CSS_LUXBAR}}"
     "</style>"
-    "</head>"
-    "<body style=\"padding-top:58px;\">"
+  "</head>"
+  "<body style=\"padding-top:58px;\">"
     "<div class=\"container\">"
-    "{{MENU_PRE}}"
-    "{{MENU_AUX}}"
-    "{{MENU_POST}}"
-    "<div class=\"base-panel\">"
-    "<form id=\"_sid\" action=\"" AUTOCONNECT_URI_CONNECT "\" method=\"post\">"
-    "{{OPEN_SSID}}"
-    "</form>"
-    "</div>"
+      "{{MENU_PRE}}"
+      "{{MENU_AUX}}"
+      "{{MENU_POST}}"
+      "<div class=\"base-panel\">"
+        "<form id=\"_sid\" action=\"" AUTOCONNECT_URI_CONNECT "\" method=\"post\">"
+          "{{OPEN_SSID}}"
+        "</form>"
+      "</div>"
     "</div>"
     "<script type=\"text/javascript\">"
-    "function crdel(e){if(confirm(`${e} " AUTOCONNECT_TEXT_DELETECREDENTIAL "`)){var t=document.getElementById('_sid');t.setAttribute('action','" AUTOCONNECT_URI_DELETE "');var i=document.createElement('input');i.setAttribute('type','hidden'),i.setAttribute('name','del'),i.setAttribute('value',e),t.appendChild(i),t.submit()}}"
+      "function crdel(e){if(confirm(`${e} " AUTOCONNECT_TEXT_DELETECREDENTIAL "`)){var t=document.getElementById('_sid');t.setAttribute('action','" AUTOCONNECT_URI_DELETE "');var i=document.createElement('input');i.setAttribute('type','hidden'),i.setAttribute('name','del'),i.setAttribute('value',e),t.appendChild(i),t.submit()}}"
     "</script>"
-    "</body>"
-    "</html>"};
+  "</body>"
+  "</html>"
+};
 
 /**< A page that informs during a connection attempting. */
-template <typename T>
-const char AutoConnectCore<T>::_PAGE_CONNECTING[] PROGMEM = {
-    "{{REQ}}"
-    "{{HEAD}}"
+template<typename T>
+const char  AutoConnectCore<T>::_PAGE_CONNECTING[] PROGMEM = {
+  "{{REQ}}"
+  "{{HEAD}}"
     "<title>" AUTOCONNECT_PAGETITLE_CONNECTING "</title>"
     "<style type=\"text/css\">"
-    "{{CSS_BASE}}"
-    "{{CSS_SPINNER}}"
-    "{{CSS_LUXBAR}}"
+      "{{CSS_BASE}}"
+      "{{CSS_SPINNER}}"
+      "{{CSS_LUXBAR}}"
     "</style>"
-    "</head>"
-    "<body style=\"padding-top:58px;\">"
+  "</head>"
+  "<body style=\"padding-top:58px;\">"
     "<div class=\"container\">"
-    "{{MENU_PRE}}"
-    "{{MENU_POST}}"
-    "<div class=\"spinner\">"
-    "<div class=\"dbl-bounce1\"></div>"
-    "<div class=\"dbl-bounce2\"></div>"
-    "<div style=\"position:absolute;left:-100%;right:-100%;text-align:center;margin:10px auto;font-weight:bold;color:#0b0b33;\">{{CUR_SSID}}</div>"
-    "</div>"
+      "{{MENU_PRE}}"
+      "{{MENU_POST}}"
+      "<div class=\"spinner\">"
+        "<div class=\"dbl-bounce1\"></div>"
+        "<div class=\"dbl-bounce2\"></div>"
+        "<div style=\"position:absolute;left:-100%;right:-100%;text-align:center;margin:10px auto;font-weight:bold;color:#0b0b33;\">{{CUR_SSID}}</div>"
+      "</div>"
     "</div>"
     "<script type=\"text/javascript\">"
-    "setTimeout(\"link()\"," AUTOCONNECT_STRING_DEPLOY(AUTOCONNECT_RESPONSE_WAITTIME) ");"
-                                                                                      "function link(){location.href='" AUTOCONNECT_URI_RESULT "';}"
-                                                                                      "</script>"
-                                                                                      "</body>"
-                                                                                      "</html>"};
+      "setTimeout(\"link()\"," AUTOCONNECT_STRING_DEPLOY(AUTOCONNECT_RESPONSE_WAITTIME) ");"
+      "function link(){location.href='" AUTOCONNECT_URI_RESULT "';}"
+    "</script>"
+  "</body>"
+  "</html>"
+};
 
 /**< A page announcing that a connection has been established. */
-template <typename T>
-const char AutoConnectCore<T>::_PAGE_SUCCESS[] PROGMEM = {
-    "{{HEAD}}"
+template<typename T>
+const char  AutoConnectCore<T>::_PAGE_SUCCESS[] PROGMEM = {
+  "{{HEAD}}"
     "<title>" AUTOCONNECT_PAGETITLE_STATISTICS "</title>"
     "<style type=\"text/css\">"
-    "{{CSS_BASE}}"
-    "{{CSS_TABLE}}"
-    "{{CSS_LUXBAR}}"
+      "{{CSS_BASE}}"
+      "{{CSS_TABLE}}"
+      "{{CSS_LUXBAR}}"
     "</style>"
-    "</head>"
-    "<body style=\"padding-top:58px;\">"
+  "</head>"
+  "<body style=\"padding-top:58px;\">"
     "<div class=\"container\">"
-    "{{MENU_PRE}}"
-    "{{MENU_AUX}}"
-    "{{MENU_POST}}"
-    "<div>"
-    "<table class=\"info\" style=\"border:none;\">"
-    "<tbody>"
-    "<tr>"
-    "<td>" AUTOCONNECT_PAGESTATS_ESTABLISHEDCONNECTION "</td>"
-    "<td>{{ESTAB_SSID}}</td>"
-    "</tr>"
-    "<tr>"
-    "<td>" AUTOCONNECT_PAGESTATS_MODE "</td>"
-    "<td>{{WIFI_MODE}}({{WIFI_STATUS}})</td>"
-    "</tr>"
-    "<tr>"
-    "<td>" AUTOCONNECT_PAGESTATS_IP "</td>"
-    "<td>{{LOCAL_IP}}</td>"
-    "</tr>"
-    "<td>" AUTOCONNECT_PAGESTATS_GATEWAY "</td>"
-    "<td>{{GATEWAY}}</td>"
-    "</tr>"
-    "<tr>"
-    "<td>" AUTOCONNECT_PAGESTATS_SUBNETMASK "</td>"
-    "<td>{{NETMASK}}</td>"
-    "</tr>"
-    "<tr>"
-    "<td>" AUTOCONNECT_PAGESTATS_CHANNEL "</td>"
-    "<td>{{CHANNEL}}</td>"
-    "</tr>"
-    "<tr>"
-    "<td>" AUTOCONNECT_PAGESTATS_DBM "</td>"
-    "<td>{{DBM}}</td>"
-    "</tr>"
-    "</tbody>"
-    "</table>"
+      "{{MENU_PRE}}"
+      "{{MENU_AUX}}"
+      "{{MENU_POST}}"
+      "<div>"
+        "<table class=\"info\" style=\"border:none;\">"
+          "<tbody>"
+          "<tr>"
+            "<td>" AUTOCONNECT_PAGESTATS_ESTABLISHEDCONNECTION "</td>"
+            "<td>{{ESTAB_SSID}}</td>"
+          "</tr>"
+          "<tr>"
+            "<td>" AUTOCONNECT_PAGESTATS_MODE "</td>"
+            "<td>{{WIFI_MODE}}({{WIFI_STATUS}})</td>"
+          "</tr>"
+          "<tr>"
+            "<td>" AUTOCONNECT_PAGESTATS_IP "</td>"
+            "<td>{{LOCAL_IP}}</td>"
+          "</tr>"
+            "<td>" AUTOCONNECT_PAGESTATS_GATEWAY "</td>"
+            "<td>{{GATEWAY}}</td>"
+          "</tr>"
+          "<tr>"
+            "<td>" AUTOCONNECT_PAGESTATS_SUBNETMASK "</td>"
+            "<td>{{NETMASK}}</td>"
+          "</tr>"
+          "<tr>"
+            "<td>" AUTOCONNECT_PAGESTATS_CHANNEL "</td>"
+            "<td>{{CHANNEL}}</td>"
+          "</tr>"
+          "<tr>"
+            "<td>" AUTOCONNECT_PAGESTATS_DBM "</td>"
+            "<td>{{DBM}}</td>"
+          "</tr>"
+          "</tbody>"
+        "</table>"
+      "</div>"
     "</div>"
-    "</div>"
-    "</body>"
-    "</html>"};
+  "</body>"
+  "</html>"
+};
 
 /**< A response page for connection failed. */
-template <typename T>
-const char AutoConnectCore<T>::_PAGE_FAIL[] PROGMEM = {
-    "{{HEAD}}"
+template<typename T>
+const char  AutoConnectCore<T>::_PAGE_FAIL[] PROGMEM = {
+  "{{HEAD}}"
     "<title>" AUTOCONNECT_PAGETITLE_CONNECTIONFAILED "</title>"
     "<style type=\"text/css\">"
-    "{{CSS_BASE}}"
-    "{{CSS_TABLE}}"
-    "{{CSS_LUXBAR}}"
+      "{{CSS_BASE}}"
+      "{{CSS_TABLE}}"
+      "{{CSS_LUXBAR}}"
     "</style>"
-    "</head>"
-    "<body style=\"padding-top:58px;\">"
+  "</head>"
+  "<body style=\"padding-top:58px;\">"
     "<div class=\"container\">"
-    "{{MENU_PRE}}"
-    "{{MENU_AUX}}"
-    "{{MENU_POST}}"
-    "<div>"
-    "<table class=\"info\" style=\"border:none;\">"
-    "<tbody>"
-    "<tr>"
-    "<td>" AUTOCONNECT_PAGECONNECTIONFAILED_CONNECTIONFAILED "</td>"
-    "<td>{{STATION_STATUS}}</td>"
-    "</tr>"
-    "</tbody>"
-    "</table>"
+      "{{MENU_PRE}}"
+      "{{MENU_AUX}}"
+      "{{MENU_POST}}"
+      "<div>"
+        "<table class=\"info\" style=\"border:none;\">"
+          "<tbody>"
+          "<tr>"
+            "<td>" AUTOCONNECT_PAGECONNECTIONFAILED_CONNECTIONFAILED "</td>"
+            "<td>{{STATION_STATUS}}</td>"
+          "</tr>"
+          "</tbody>"
+        "</table>"
+      "</div>"
     "</div>"
-    "</div>"
-    "</body>"
-    "</html>"};
+  "</body>"
+  "</html>"
+};
 
 /**< A response page for disconnected from the AP. */
-template <typename T>
-const char AutoConnectCore<T>::_PAGE_DISCONN[] PROGMEM = {
-    "{{DISCONNECT}}"
-    "{{HEAD}}"
+template<typename T>
+const char  AutoConnectCore<T>::_PAGE_DISCONN[] PROGMEM = {
+  "{{DISCONNECT}}"
+  "{{HEAD}}"
     "<title>" AUTOCONNECT_PAGETITLE_DISCONNECTED "</title>"
     "<style type=\"text/css\">"
-    "{{CSS_BASE}}"
-    "{{CSS_LUXBAR}}"
+      "{{CSS_BASE}}"
+      "{{CSS_LUXBAR}}"
     "</style>"
-    "</head>"
-    "<body style=\"padding-top:58px;\">"
+  "</head>"
+  "<body style=\"padding-top:58px;\">"
     "<div class=\"container\">"
-    "{{MENU_PRE}}"
-    "{{MENU_POST}}"
+      "{{MENU_PRE}}"
+      "{{MENU_POST}}"
     "</div>"
-    "</body>"
-    "</html>"};
+  "</body>"
+  "</html>"
+};
 
-template <typename T>
-uint32_t AutoConnectCore<T>::_getChipId()
-{
+template<typename T>
+uint32_t AutoConnectCore<T>::_getChipId() {
 #if defined(ARDUINO_ARCH_ESP8266)
   return ESP.getChipId();
 #elif defined(ARDUINO_ARCH_ESP32)
-  uint64_t chipId;
+  uint64_t  chipId;
   chipId = ESP.getEfuseMac();
   return (uint32_t)(chipId >> 32);
 #endif
 }
 
-template <typename T>
-uint32_t AutoConnectCore<T>::_getFlashChipRealSize()
-{
+template<typename T>
+uint32_t AutoConnectCore<T>::_getFlashChipRealSize() {
 #if defined(ARDUINO_ARCH_ESP8266)
   return ESP.getFlashChipRealSize();
 #elif defined(ARDUINO_ARCH_ESP32)
@@ -921,8 +939,7 @@ uint32_t AutoConnectCore<T>::_getFlashChipRealSize()
 }
 
 template <typename T>
-String AutoConnectCore<T>::_getSystemUptime()
-{
+String AutoConnectCore<T>::_getSystemUptime() {
 #if defined(ARDUINO_ARCH_ESP8266)
   time_t millisecs = millis();
 #elif defined(ARDUINO_ARCH_ESP32)
@@ -955,76 +972,66 @@ String AutoConnectCore<T>::_token_CSS_BASE(PageArgument &args)
   return String(FPSTR(_CSS_BASE));
 }
 
-template <typename T>
-String AutoConnectCore<T>::_token_CSS_ICON_LOCK(PageArgument &args)
-{
+template<typename T>
+String AutoConnectCore<T>::_token_CSS_ICON_LOCK(PageArgument& args) {
   AC_UNUSED(args);
   return String(FPSTR(_CSS_ICON_LOCK));
 }
 
-template <typename T>
-String AutoConnectCore<T>::_token_CSS_ICON_TRASH(PageArgument &args)
-{
+template<typename T>
+String AutoConnectCore<T>::_token_CSS_ICON_TRASH(PageArgument& args) {
   AC_UNUSED(args);
   return (_apConfig.menuItems & AC_MENUITEM_DELETESSID) ? String(FPSTR(_CSS_ICON_TRASH)) : String("");
 }
 
-template <typename T>
-String AutoConnectCore<T>::_token_CSS_INPUT_BUTTON(PageArgument &args)
-{
+template<typename T>
+String AutoConnectCore<T>::_token_CSS_INPUT_BUTTON(PageArgument& args) {
   AC_UNUSED(args);
   return String(FPSTR(_CSS_INPUT_BUTTON));
 }
 
-template <typename T>
-String AutoConnectCore<T>::_token_CSS_INPUT_TEXT(PageArgument &args)
-{
+template<typename T>
+String AutoConnectCore<T>::_token_CSS_INPUT_TEXT(PageArgument& args) {
   AC_UNUSED(args);
   return String(FPSTR(_CSS_INPUT_TEXT));
 }
 
-template <typename T>
-String AutoConnectCore<T>::_token_CSS_LUXBAR(PageArgument &args)
-{
+template<typename T>
+String AutoConnectCore<T>::_token_CSS_LUXBAR(PageArgument& args) {
   AC_UNUSED(args);
   return String(FPSTR(_CSS_LUXBAR));
 }
 
-template <typename T>
-String AutoConnectCore<T>::_token_CSS_SPINNER(PageArgument &args)
-{
+template<typename T>
+String AutoConnectCore<T>::_token_CSS_SPINNER(PageArgument& args) {
   AC_UNUSED(args);
   return String(FPSTR(_CSS_SPINNER));
 }
 
-template <typename T>
-String AutoConnectCore<T>::_token_CSS_TABLE(PageArgument &args)
-{
+template<typename T>
+String AutoConnectCore<T>::_token_CSS_TABLE(PageArgument& args) {
   AC_UNUSED(args);
   return String(FPSTR(_CSS_TABLE));
 }
 
-template <typename T>
-String AutoConnectCore<T>::_token_CSS_UL(PageArgument &args)
-{
+template<typename T>
+String AutoConnectCore<T>::_token_CSS_UL(PageArgument& args) {
   AC_UNUSED(args);
   return String(FPSTR(_CSS_UL));
 }
 
-template <typename T>
-String AutoConnectCore<T>::_token_MENU_AUX(PageArgument &args)
-{
+template<typename T>
+String AutoConnectCore<T>::_token_MENU_AUX(PageArgument& args) {
   return _mold_MENU_AUX(args);
 }
 
-template <typename T>
-String AutoConnectCore<T>::_token_MENU_PRE(PageArgument &args)
-{
-  String currentMenu = FPSTR(_ELM_MENU_PRE);
-  String menuItem = _attachMenuItem(AC_MENUITEM_CONFIGNEW) +
-                    _attachMenuItem(AC_MENUITEM_OPENSSIDS) +
-                    _attachMenuItem(AC_MENUITEM_DISCONNECT) +
-                    _attachMenuItem(AC_MENUITEM_RESET);
+template<typename T>
+String AutoConnectCore<T>::_token_MENU_PRE(PageArgument& args) {
+  String  currentMenu = FPSTR(_ELM_MENU_PRE);
+  String  menuItem = _attachMenuItem(AC_MENUITEM_CONFIGNEW) +
+                     _attachMenuItem(AC_MENUITEM_OPENSSIDS) +
+                     _attachMenuItem(AC_MENUITEM_DISCONNECT) +
+                     _attachMenuItem(AC_MENUITEM_RESET);
   currentMenu.replace(String(F("MENU_LIST")), menuItem);
   currentMenu.replace(String(F("BOOT_URI")), _getBootUri());
   currentMenu.replace(String(F("MENU_TITLE")), _menuTitle);
@@ -1032,72 +1039,65 @@ String AutoConnectCore<T>::_token_MENU_PRE(PageArgument &args)
   return currentMenu;
 }
 
-template <typename T>
-String AutoConnectCore<T>::_token_MENU_POST(PageArgument &args)
-{
+template<typename T>
+String AutoConnectCore<T>::_token_MENU_POST(PageArgument& args) {
   AC_UNUSED(args);
-  String postMenu = FPSTR(_ELM_MENU_POST);
+  String  postMenu = FPSTR(_ELM_MENU_POST);
   postMenu.replace(String(F("MENU_HOME")), _attachMenuItem(AC_MENUITEM_HOME));
   postMenu.replace(String(F("HOME_URI")), _apConfig.homeUri);
   postMenu.replace(String(F("MENU_DEVINFO")), _attachMenuItem(AC_MENUITEM_DEVINFO));
   return postMenu;
 }
 
-template <typename T>
-String AutoConnectCore<T>::_token_AP_MAC(PageArgument &args)
-{
+template<typename T>
+String AutoConnectCore<T>::_token_AP_MAC(PageArgument& args) {
   AC_UNUSED(args);
   uint8_t macAddress[6];
   WiFi.softAPmacAddress(macAddress);
   return AutoConnectCore<T>::_toMACAddressString(macAddress);
 }
 
-template <typename T>
-String AutoConnectCore<T>::_token_BOOTURI(PageArgument &args)
-{
+template<typename T>
+String AutoConnectCore<T>::_token_BOOTURI(PageArgument& args) {
   AC_UNUSED(args);
   return _getBootUri();
 }
 
-template <typename T>
-String AutoConnectCore<T>::_token_CHANNEL(PageArgument &args)
-{
+template<typename T>
+String AutoConnectCore<T>::_token_CHANNEL(PageArgument& args) {
   AC_UNUSED(args);
   return String(WiFi.channel());
 }
 
-template <typename T>
-String AutoConnectCore<T>::_token_CHIP_ID(PageArgument &args)
-{
+template<typename T>
+String AutoConnectCore<T>::_token_CHIP_ID(PageArgument& args) {
   AC_UNUSED(args);
   return String(_getChipId());
 }
 
-template <typename T>
-String AutoConnectCore<T>::_token_CONFIG_STAIP(PageArgument &args)
-{
+template<typename T>
+String AutoConnectCore<T>::_token_CONFIG_STAIP(PageArgument& args) {
   AC_UNUSED(args);
   static const char _configIPList[] PROGMEM =
-      "<li class=\"exp\">"
-      "<label for=\"%s\">%s</label>"
-      "<input id=\"%s\" type=\"text\" name=\"%s\" value=\"%s\">"
-      "</li>";
-  struct _reps
-  {
+    "<li class=\"exp\">"
+    "<label for=\"%s\">%s</label>"
+    "<input id=\"%s\" type=\"text\" name=\"%s\" value=\"%s\">"
+    "</li>";
+  struct _reps {
     PGM_P lid;
     PGM_P lbl;
-  } static const reps[] = {
-      {PSTR(AUTOCONNECT_PARAMID_STAIP), PSTR(AUTOCONNECT_PAGECONFIG_IPADDRESS)},
-      {PSTR(AUTOCONNECT_PARAMID_GTWAY), PSTR(AUTOCONNECT_PAGECONFIG_GATEWAY)},
-      {PSTR(AUTOCONNECT_PARAMID_NTMSK), PSTR(AUTOCONNECT_PAGECONFIG_NETMASK)},
-      {PSTR(AUTOCONNECT_PARAMID_DNS1), PSTR(AUTOCONNECT_PAGECONFIG_DNS1)},
-      {PSTR(AUTOCONNECT_PARAMID_DNS2), PSTR(AUTOCONNECT_PAGECONFIG_DNS2)}};
-  char liCont[600];
-  char *liBuf = liCont;
+  } static const reps[]  = {
+    { PSTR(AUTOCONNECT_PARAMID_STAIP), PSTR(AUTOCONNECT_PAGECONFIG_IPADDRESS) },
+    { PSTR(AUTOCONNECT_PARAMID_GTWAY), PSTR(AUTOCONNECT_PAGECONFIG_GATEWAY) },
+    { PSTR(AUTOCONNECT_PARAMID_NTMSK), PSTR(AUTOCONNECT_PAGECONFIG_NETMASK) },
+    { PSTR(AUTOCONNECT_PARAMID_DNS1), PSTR(AUTOCONNECT_PAGECONFIG_DNS1) },
+    { PSTR(AUTOCONNECT_PARAMID_DNS2), PSTR(AUTOCONNECT_PAGECONFIG_DNS2) }
+  };
+  char  liCont[600];
+  char* liBuf = liCont;
 
-  for (uint8_t i = 0; i < 5; i++)
-  {
-    IPAddress *ip = nullptr;
+  for (uint8_t i = 0; i < 5; i++) {
+    IPAddress*  ip = nullptr;
     if (i == 0)
       ip = &_apConfig.staip;
     else if (i == 1)
@@ -1108,56 +1108,50 @@ String AutoConnectCore<T>::_token_CONFIG_STAIP(PageArgument &args)
       ip = &_apConfig.dns1;
     else if (i == 4)
       ip = &_apConfig.dns2;
-    String ipStr = ip != nullptr ? ip->toString() : String(F("0.0.0.0"));
+    String  ipStr = ip != nullptr ? ip->toString() : String(F("0.0.0.0"));
     snprintf_P(liBuf, sizeof(liCont) - (liBuf - liCont), (PGM_P)_configIPList, reps[i].lid, reps[i].lbl, reps[i].lid, reps[i].lid, ipStr.c_str());
     liBuf += strlen(liBuf);
   }
   return String(liCont);
 }
 
-template <typename T>
-String AutoConnectCore<T>::_token_CPU_FREQ(PageArgument &args)
-{
+template<typename T>
+String AutoConnectCore<T>::_token_CPU_FREQ(PageArgument& args) {
   AC_UNUSED(args);
   return String(ESP.getCpuFreqMHz());
 }
 
-template <typename T>
-String AutoConnectCore<T>::_token_CURRENT_SSID(PageArgument &args)
-{
+template<typename T>
+String AutoConnectCore<T>::_token_CURRENT_SSID(PageArgument& args) {
   AC_UNUSED(args);
-  char ssid_c[sizeof(station_config_t::ssid) + 1];
+  char  ssid_c[sizeof(station_config_t::ssid) + 1];
   *ssid_c = '\0';
-  strncat(ssid_c, reinterpret_cast<char *>(_credential.ssid), sizeof(ssid_c) - 1);
-  String ssid = String(ssid_c);
+  strncat(ssid_c, reinterpret_cast<char*>(_credential.ssid), sizeof(ssid_c) - 1);
+  String  ssid = String(ssid_c);
   return ssid;
 }
 
-template <typename T>
-String AutoConnectCore<T>::_token_DBM(PageArgument &args)
-{
+template<typename T>
+String AutoConnectCore<T>::_token_DBM(PageArgument& args) {
   AC_UNUSED(args);
   int32_t dBm = WiFi.RSSI();
   return (dBm == 31 ? String(F("N/A")) : String(dBm));
 }
 
-template <typename T>
-String AutoConnectCore<T>::_token_ESTAB_SSID(PageArgument &args)
-{
+template<typename T>
+String AutoConnectCore<T>::_token_ESTAB_SSID(PageArgument& args) {
   AC_UNUSED(args);
   return (WiFi.status() == WL_CONNECTED ? WiFi.SSID() : String(F("N/A")));
 }
 
-template <typename T>
-String AutoConnectCore<T>::_token_FLASH_SIZE(PageArgument &args)
-{
+template<typename T>
+String AutoConnectCore<T>::_token_FLASH_SIZE(PageArgument& args) {
   AC_UNUSED(args);
   return String(_getFlashChipRealSize());
 }
 
-template <typename T>
-String AutoConnectCore<T>::_token_FREE_HEAP(PageArgument &args)
-{
+template<typename T>
+String AutoConnectCore<T>::_token_FREE_HEAP(PageArgument& args) {
   AC_UNUSED(args);
   return String(_freeHeapSize);
 }
@@ -1176,23 +1170,20 @@ String AutoConnectCore<T>::_token_GATEWAY(PageArgument &args)
   return WiFi.gatewayIP().toString();
 }
 
-template <typename T>
-String AutoConnectCore<T>::_token_HEAD(PageArgument &args)
-{
+template<typename T>
+String AutoConnectCore<T>::_token_HEAD(PageArgument& args) {
   AC_UNUSED(args);
   return String(FPSTR(_ELM_HTML_HEAD));
 }
 
-template <typename T>
-String AutoConnectCore<T>::_token_HIDDEN_COUNT(PageArgument &args)
-{
+template<typename T>
+String AutoConnectCore<T>::_token_HIDDEN_COUNT(PageArgument& args) {
   AC_UNUSED(args);
   return String(_hiddenSSIDCount);
 }
 
-template <typename T>
-String AutoConnectCore<T>::_token_LIST_SSID(PageArgument &args)
-{
+template<typename T>
+String AutoConnectCore<T>::_token_LIST_SSID(PageArgument& args) {
   // Obtain the page number to display.
   // When the display request is the first page, it will be obtained
   // from the scan results of the WiFiScan class if it has already been
@@ -1200,19 +1191,17 @@ String AutoConnectCore<T>::_token_LIST_SSID(PageArgument &args)
   uint8_t page = 0;
   if (args.hasArg(String(F("page"))))
     page = args.arg("page").toInt();
-  else
-  {
+  else {
     // Scan at a first time
     _scanCount = WiFi.scanNetworks(false, true);
     AC_DBG("%d network(s) found, ", (int)_scanCount);
   }
   // Prepare SSID list content building buffer
-  size_t bufSize = sizeof('\0') + 192 * (_scanCount > AUTOCONNECT_SSIDPAGEUNIT_LINES ? AUTOCONNECT_SSIDPAGEUNIT_LINES : _scanCount);
+  size_t  bufSize = sizeof('\0') + 192 * (_scanCount > AUTOCONNECT_SSIDPAGEUNIT_LINES ? AUTOCONNECT_SSIDPAGEUNIT_LINES : _scanCount);
   bufSize += 88 * (_scanCount > AUTOCONNECT_SSIDPAGEUNIT_LINES ? (_scanCount > (AUTOCONNECT_SSIDPAGEUNIT_LINES * 2) ? 2 : 1) : 0);
   AC_DBG_DUMB("%d buf", bufSize);
-  char *ssidList = (char *)malloc(bufSize);
-  if (!ssidList)
-  {
+  char* ssidList = (char*)malloc(bufSize);
+  if (!ssidList) {
     AC_DBG_DUMB(" alloc. failed\n");
     WiFi.scanDelete();
     return _emptyString;
@@ -1220,29 +1209,25 @@ String AutoConnectCore<T>::_token_LIST_SSID(PageArgument &args)
   AC_DBG_DUMB("\n");
   // Locate to the page and build SSD list content.
   static const char _ssidList[] PROGMEM =
-      "<input type=\"button\" onClick=\"onFocus(this.getAttribute('value'))\" value=\"%s\">"
-      "<label class=\"slist\">%d&#037;&ensp;Ch.%d</label>%s<br>";
+    "<input type=\"button\" onClick=\"onFocus(this.getAttribute('value'))\" value=\"%s\">"
+    "<label class=\"slist\">%d&#037;&ensp;Ch.%d</label>%s<br>";
   static const char _ssidEnc[] PROGMEM =
-      "<span class=\"img-lock\"></span>";
+    "<span class=\"img-lock\"></span>";
   static const char _ssidPage[] PROGMEM =
-      "<button type=\"submit\" name=\"page\" value=\"%d\" formaction=\"" AUTOCONNECT_URI_CONFIG "\">%s</button>&emsp;";
+    "<button type=\"submit\" name=\"page\" value=\"%d\" formaction=\"" AUTOCONNECT_URI_CONFIG "\">%s</button>&emsp;";
   _hiddenSSIDCount = 0;
   uint8_t validCount = 0;
   uint8_t dispCount = 0;
-  char *slBuf = ssidList;
+  char* slBuf = ssidList;
   *slBuf = '\0';
-  for (uint8_t i = 0; i < _scanCount; i++)
-  {
+  for (uint8_t i = 0; i < _scanCount; i++) {
     String ssid = WiFi.SSID(i);
-    if (ssid.length() > 0)
-    {
+    if (ssid.length() > 0) {
       // An available SSID may be listed.
       // AUTOCONNECT_SSIDPAGEUNIT_LINES determines the number of lines
       // per page in the available SSID list.
-      if (validCount >= page * AUTOCONNECT_SSIDPAGEUNIT_LINES && validCount <= (page + 1) * AUTOCONNECT_SSIDPAGEUNIT_LINES - 1)
-      {
-        if (++dispCount <= AUTOCONNECT_SSIDPAGEUNIT_LINES)
-        {
+      if (validCount >= page * AUTOCONNECT_SSIDPAGEUNIT_LINES && validCount <= (page + 1) * AUTOCONNECT_SSIDPAGEUNIT_LINES - 1) {
+        if (++dispCount <= AUTOCONNECT_SSIDPAGEUNIT_LINES) {
           snprintf_P(slBuf, bufSize - (slBuf - ssidList), (PGM_P)_ssidList, ssid.c_str(), AutoConnectCore<T>::_toWiFiQuality((int32_t)WiFi.RSSI(i)), WiFi.channel(i), WiFi.encryptionType(i) != ENC_TYPE_NONE ? (PGM_P)_ssidEnc : "");
           slBuf += strlen(slBuf);
         }
@@ -1255,14 +1240,12 @@ String AutoConnectCore<T>::_token_LIST_SSID(PageArgument &args)
       _hiddenSSIDCount++;
   }
   // Prepare perv. button
-  if (page >= 1)
-  {
+  if (page >= 1) {
     snprintf_P(slBuf, bufSize - (slBuf - ssidList), (PGM_P)_ssidPage, page - 1, PSTR("Prev."));
     slBuf = ssidList + strlen(ssidList);
   }
   // Prepare next button
-  if (validCount > (page + 1) * AUTOCONNECT_SSIDPAGEUNIT_LINES)
-  {
+  if (validCount > (page + 1) * AUTOCONNECT_SSIDPAGEUNIT_LINES) {
     snprintf_P(slBuf, bufSize - (slBuf - ssidList), (PGM_P)_ssidPage, page + 1, PSTR("Next"));
   }
   String ssidListStr = String(ssidList);
@@ -1270,41 +1253,37 @@ String AutoConnectCore<T>::_token_LIST_SSID(PageArgument &args)
   return ssidListStr;
 }
 
-template <typename T>
-String AutoConnectCore<T>::_token_LOCAL_IP(PageArgument &args)
-{
+template<typename T>
+String AutoConnectCore<T>::_token_LOCAL_IP(PageArgument& args) {
   AC_UNUSED(args);
   return WiFi.localIP().toString();
 }
 
-template <typename T>
-String AutoConnectCore<T>::_token_NETMASK(PageArgument &args)
-{
+template<typename T>
+String AutoConnectCore<T>::_token_NETMASK(PageArgument& args) {
   AC_UNUSED(args);
   return WiFi.subnetMask().toString();
 }
 
-template <typename T>
-String AutoConnectCore<T>::_token_OPEN_SSID(PageArgument &args)
-{
+template<typename T>
+String AutoConnectCore<T>::_token_OPEN_SSID(PageArgument& args) {
   AC_UNUSED(args);
   static const char _ssidUndeleted[] PROGMEM = "<div style=\"color:red\">%s " AUTOCONNECT_TEXT_COULDNOTDELETED "</div>";
   static const char _ssidList[] PROGMEM = "<input id=\"sb\" type=\"submit\" name=\"%s\" value=\"%s\"><label class=\"slist\">%s</label>%s%s<br>";
   static const char _ssidRssi[] PROGMEM = "%d&#037;&ensp;Ch.%d";
-  static const char _ssidNA[] PROGMEM = "N/A";
+  static const char _ssidNA[]   PROGMEM = "N/A";
   static const char _ssidTrsh[] PROGMEM = "<a onclick=\"crdel('%s')\" class=\"img-trash\"></a>";
   static const char _ssidLock[] PROGMEM = "<span class=\"img-lock\"></span>";
   static const char _ssidNull[] PROGMEM = "";
   String ssidList;
-  station_config_t entry;
-  char rssiCont[32];
-  char trash[80] = {'\0'};
-  char slCont[sizeof(_ssidList) + sizeof(AUTOCONNECT_PARAMID_CRED) + sizeof(station_config_t::ssid) + sizeof(rssiCont) + sizeof(trash) + sizeof(_ssidLock)];
+  station_config_t  entry;
+  char  rssiCont[32];
+  char  trash[80] = {'\0'};
+  char  slCont[sizeof(_ssidList) + sizeof(AUTOCONNECT_PARAMID_CRED) + sizeof(station_config_t::ssid) + sizeof(rssiCont) + sizeof(trash) + sizeof(_ssidLock)];
   AutoConnectCredential credit(_apConfig.boundaryOffset);
 
-  if (_indelibleSSID.length())
-  {
-    char indelible[82];
+  if (_indelibleSSID.length()) {
+    char  indelible[82];
 
     snprintf_P(indelible, sizeof(indelible), _ssidUndeleted, _indelibleSSID.c_str());
     ssidList = String(indelible);
@@ -1317,17 +1296,14 @@ String AutoConnectCore<T>::_token_OPEN_SSID(PageArgument &args)
   else
     ssidList += String(F("<p><b>" AUTOCONNECT_TEXT_NOSAVEDCREDENTIALS "</b></p>"));
 
-  for (uint8_t i = 0; i < creEntries; i++)
-  {
+  for (uint8_t i = 0; i < creEntries; i++) {
     rssiCont[0] = '\0';
     PGM_P rssiSym = _ssidNA;
     PGM_P ssidLock = _ssidNull;
     credit.load(i, &entry);
     AC_DBG("Credential #%d loaded\n", (int)i);
-    for (int8_t sc = 0; sc < (int8_t)_scanCount; sc++)
-    {
-      if (_isValidAP(entry, sc))
-      {
+    for (int8_t sc = 0; sc < (int8_t)_scanCount; sc++) {
+      if (_isValidAP(entry, sc)) {
         // The access point collation key is determined at compile time
         // according to the AUTOCONNECT_APKEY_SSID definition, which is
         // either BSSID or SSID.
@@ -1340,40 +1316,36 @@ String AutoConnectCore<T>::_token_OPEN_SSID(PageArgument &args)
       }
     }
     if (_apConfig.menuItems & AC_MENUITEM_DELETESSID)
-      snprintf_P(trash, sizeof(trash), (PGM_P)_ssidTrsh, reinterpret_cast<char *>(entry.ssid));
+      snprintf_P(trash, sizeof(trash), (PGM_P)_ssidTrsh, reinterpret_cast<char*>(entry.ssid));
 
-    snprintf_P(slCont, sizeof(slCont), (PGM_P)_ssidList, AUTOCONNECT_PARAMID_CRED, reinterpret_cast<char *>(entry.ssid), rssiSym, trash, ssidLock);
+    snprintf_P(slCont, sizeof(slCont), (PGM_P)_ssidList, AUTOCONNECT_PARAMID_CRED, reinterpret_cast<char*>(entry.ssid), rssiSym, trash, ssidLock);
     ssidList += String(slCont);
   }
   return ssidList;
 }
 
-template <typename T>
-String AutoConnectCore<T>::_token_SOFTAP_IP(PageArgument &args)
-{
+template<typename T>
+String AutoConnectCore<T>::_token_SOFTAP_IP(PageArgument& args) {
   AC_UNUSED(args);
   return WiFi.softAPIP().toString();
 }
 
-template <typename T>
-String AutoConnectCore<T>::_token_SSID_COUNT(PageArgument &args)
-{
+template<typename T>
+String AutoConnectCore<T>::_token_SSID_COUNT(PageArgument& args) {
   AC_UNUSED(args);
   return String(_scanCount);
 }
 
-template <typename T>
-String AutoConnectCore<T>::_token_STA_MAC(PageArgument &args)
-{
+template<typename T>
+String AutoConnectCore<T>::_token_STA_MAC(PageArgument& args) {
   AC_UNUSED(args);
   uint8_t macAddress[6];
   WiFi.macAddress(macAddress);
   return AutoConnectCore<T>::_toMACAddressString(macAddress);
 }
 
-template <typename T>
-String AutoConnectCore<T>::_token_STATION_STATUS(PageArgument &args)
-{
+template<typename T>
+String AutoConnectCore<T>::_token_STATION_STATUS(PageArgument& args) {
   AC_UNUSED(args);
   PGM_P wlStatusSymbol = PSTR("");
   PGM_P wlStatusSymbols[] = {
@@ -1385,8 +1357,7 @@ String AutoConnectCore<T>::_token_STATION_STATUS(PageArgument &args)
     PSTR("CONNECT_FAIL"),
     PSTR("GOT_IP")
   };
-  switch (wifi_station_get_connect_status())
-  {
+  switch (wifi_station_get_connect_status()) {
   case STATION_IDLE:
     wlStatusSymbol = wlStatusSymbols[0];
     break;
@@ -1415,8 +1386,7 @@ String AutoConnectCore<T>::_token_STATION_STATUS(PageArgument &args)
     PSTR("DISCONNECTED"),
     PSTR("NO_SHIELD")
   };
-  switch (_rsConnect)
-  {
+  switch (_rsConnect) {
   case WL_IDLE_STATUS:
     wlStatusSymbol = wlStatusSymbols[0];
     break;
@@ -1446,20 +1416,17 @@ String AutoConnectCore<T>::_token_STATION_STATUS(PageArgument &args)
   return String("(") + String(_rsConnect) + String(") ") + String(FPSTR(wlStatusSymbol));
 }
 
-template <typename T>
-String AutoConnectCore<T>::_token_UPTIME(PageArgument &args)
-{
+template<typename T>
+String AutoConnectCore<T>::_token_UPTIME(PageArgument& args) {
   AC_UNUSED(args);
   return String(_apConfig.uptime);
 }
 
-template <typename T>
-String AutoConnectCore<T>::_token_WIFI_MODE(PageArgument &args)
-{
+template<typename T>
+String AutoConnectCore<T>::_token_WIFI_MODE(PageArgument& args) {
   AC_UNUSED(args);
   PGM_P wifiMode;
-  switch (WiFi.getMode())
-  {
+  switch (WiFi.getMode()) {
   case WIFI_OFF:
     wifiMode = PSTR("OFF");
     break;
@@ -1483,9 +1450,8 @@ String AutoConnectCore<T>::_token_WIFI_MODE(PageArgument &args)
   return String(FPSTR(wifiMode));
 }
 
-template <typename T>
-String AutoConnectCore<T>::_token_WIFI_STATUS(PageArgument &args)
-{
+template<typename T>
+String AutoConnectCore<T>::_token_WIFI_STATUS(PageArgument& args) {
   AC_UNUSED(args);
   return String(WiFi.status());
 }
@@ -1495,16 +1461,14 @@ String AutoConnectCore<T>::_token_WIFI_STATUS(PageArgument &args)
  *  @param  item  An enumerated value for the generating item configured in AutoConnectConfig.
  *  @return HTML string of a li tag with the menu item.
  */
-template <typename T>
-String AutoConnectCore<T>::_attachMenuItem(const AC_MENUITEM_t item)
-{
-  static const char _liTempl[] PROGMEM = "<li class=\"lb-item\"%s><a href=\"%s\">%s</a></li>";
+template<typename T>
+String AutoConnectCore<T>::_attachMenuItem(const AC_MENUITEM_t item) {
+  static const char _liTempl[]  PROGMEM = "<li class=\"lb-item\"%s><a href=\"%s\">%s</a></li>";
   PGM_P id = PSTR("");
   PGM_P link;
   PGM_P label;
 
-  switch (static_cast<AC_MENUITEM_t>(_apConfig.menuItems & static_cast<uint16_t>(item)))
-  {
+  switch (static_cast<AC_MENUITEM_t>(_apConfig.menuItems & static_cast<uint16_t>(item))) {
   case AC_MENUITEM_CONFIGNEW:
     link = PSTR(AUTOCONNECT_URI_CONFIG);
     label = PSTR(AUTOCONNECT_MENULABEL_CONFIGNEW);
@@ -1536,7 +1500,7 @@ String AutoConnectCore<T>::_attachMenuItem(const AC_MENUITEM_t item)
     label = nullptr;
     break;
   }
-  char li[128] = {'\0'};
+  char  li[128] = { '\0' };
   if (!!id && !!link && !!label)
     snprintf(li, sizeof(li), (PGM_P)_liTempl, id, link, label);
   return String(li);
@@ -1550,23 +1514,20 @@ String AutoConnectCore<T>::_attachMenuItem(const AC_MENUITEM_t item)
  *  @retval true  A response page generated.
  *  @retval false Requested uri is not defined.
  */
-template <typename T>
-PageElement *AutoConnectCore<T>::_setupPage(String &uri)
-{
+template<typename T>
+PageElement* AutoConnectCore<T>::_setupPage(String& uri) {
   PageElement *elm = new PageElement();
-  bool reqAuth = false;
+  bool  reqAuth = false;
 
   // Restore menu title
   _menuTitle = _apConfig.title;
 
   // Build the elements of current requested page.
-  if (uri == String(AUTOCONNECT_URI))
-  {
+  if (uri == String(AUTOCONNECT_URI)) {
 
     // Setup /_ac
     reqAuth = true;
     _freeHeapSize = ESP.getFreeHeap();
-
     elm->setMold(FPSTR(_PAGE_STAT));
     elm->addToken(FPSTR("HEAD"), std::bind(&AutoConnectCore<T>::_token_HEAD, this, std::placeholders::_1));
     elm->addToken(FPSTR("CSS_BASE"), std::bind(&AutoConnectCore<T>::_token_CSS_BASE, this, std::placeholders::_1));
@@ -1592,8 +1553,7 @@ PageElement *AutoConnectCore<T>::_setupPage(String &uri)
     elm->addToken(FPSTR("FREE_HEAP"), std::bind(&AutoConnectCore<T>::_token_FREE_HEAP, this, std::placeholders::_1));
     elm->addToken(FPSTR("SYSTEM_UPTIME"), std::bind(&AutoConnectCore<T>::_token_SYSTEM_UPTIME, this, std::placeholders::_1));
   }
-  else if (uri == String(AUTOCONNECT_URI_CONFIG) && (_apConfig.menuItems & AC_MENUITEM_CONFIGNEW))
-  {
+  else if (uri == String(AUTOCONNECT_URI_CONFIG) && (_apConfig.menuItems & AC_MENUITEM_CONFIGNEW)) {
 
     // Setup /_ac/config
     reqAuth = true;
@@ -1613,8 +1573,7 @@ PageElement *AutoConnectCore<T>::_setupPage(String &uri)
     elm->addToken(FPSTR("HIDDEN_COUNT"), std::bind(&AutoConnectCore<T>::_token_HIDDEN_COUNT, this, std::placeholders::_1));
     elm->addToken(FPSTR("CONFIG_IP"), std::bind(&AutoConnectCore<T>::_token_CONFIG_STAIP, this, std::placeholders::_1));
   }
-  else if (uri == String(AUTOCONNECT_URI_CONNECT) && (_apConfig.menuItems & AC_MENUITEM_CONFIGNEW || _apConfig.menuItems & AC_MENUITEM_OPENSSIDS))
-  {
+  else if (uri == String(AUTOCONNECT_URI_CONNECT) && (_apConfig.menuItems & AC_MENUITEM_CONFIGNEW || _apConfig.menuItems & AC_MENUITEM_OPENSSIDS)) {
 
     // Setup /_ac/connect
     reqAuth = true;
@@ -1629,8 +1588,7 @@ PageElement *AutoConnectCore<T>::_setupPage(String &uri)
     elm->addToken(FPSTR("MENU_POST"), std::bind(&AutoConnectCore<T>::_token_MENU_POST, this, std::placeholders::_1));
     elm->addToken(FPSTR("CUR_SSID"), std::bind(&AutoConnectCore<T>::_token_CURRENT_SSID, this, std::placeholders::_1));
   }
-  else if (uri == String(AUTOCONNECT_URI_OPEN) && (_apConfig.menuItems & AC_MENUITEM_OPENSSIDS))
-  {
+  else if (uri == String(AUTOCONNECT_URI_OPEN) && (_apConfig.menuItems & AC_MENUITEM_OPENSSIDS)) {
 
     // Setup /_ac/open
     reqAuth = true;
@@ -1646,16 +1604,14 @@ PageElement *AutoConnectCore<T>::_setupPage(String &uri)
     elm->addToken(FPSTR("MENU_POST"), std::bind(&AutoConnectCore<T>::_token_MENU_POST, this, std::placeholders::_1));
     elm->addToken(FPSTR("OPEN_SSID"), std::bind(&AutoConnectCore<T>::_token_OPEN_SSID, this, std::placeholders::_1));
   }
-  else if (uri == String(AUTOCONNECT_URI_DELETE) && (_apConfig.menuItems & AC_MENUITEM_OPENSSIDS) && (_apConfig.menuItems & AC_MENUITEM_DELETESSID))
-  {
-
+  else if (uri == String(AUTOCONNECT_URI_DELETE) && (_apConfig.menuItems & AC_MENUITEM_OPENSSIDS) && (_apConfig.menuItems & AC_MENUITEM_DELETESSID)) {
+  
     // Setup /_ac/del
     reqAuth = true;
     elm->setMold(FPSTR("{{DELREQ}}"));
     elm->addToken(FPSTR("DELREQ"), std::bind(&AutoConnectCore<T>::_promptDeleteCredential, this, std::placeholders::_1));
   }
-  else if (uri == String(AUTOCONNECT_URI_DISCON) && (_apConfig.menuItems & AC_MENUITEM_DISCONNECT))
-  {
+  else if (uri == String(AUTOCONNECT_URI_DISCON) && (_apConfig.menuItems & AC_MENUITEM_DISCONNECT)) {
 
     // Setup /_ac/disc
     _menuTitle = FPSTR(AUTOCONNECT_MENUTEXT_DISCONNECT);
@@ -1667,8 +1623,7 @@ PageElement *AutoConnectCore<T>::_setupPage(String &uri)
     elm->addToken(FPSTR("MENU_PRE"), std::bind(&AutoConnectCore<T>::_token_MENU_PRE, this, std::placeholders::_1));
     elm->addToken(FPSTR("MENU_POST"), std::bind(&AutoConnectCore<T>::_token_MENU_POST, this, std::placeholders::_1));
   }
-  else if (uri == String(AUTOCONNECT_URI_RESET) && (_apConfig.menuItems & AC_MENUITEM_RESET))
-  {
+  else if (uri == String(AUTOCONNECT_URI_RESET) && (_apConfig.menuItems & AC_MENUITEM_RESET)) {
 
     // Setup /_ac/reset
     reqAuth = true;
@@ -1678,15 +1633,13 @@ PageElement *AutoConnectCore<T>::_setupPage(String &uri)
     elm->addToken(FPSTR("UPTIME"), std::bind(&AutoConnectCore<T>::_token_UPTIME, this, std::placeholders::_1));
     elm->addToken(FPSTR("RESET"), std::bind(&AutoConnectCore<T>::_induceReset, this, std::placeholders::_1));
   }
-  else if (uri == String(AUTOCONNECT_URI_RESULT))
-  {
+  else if (uri == String(AUTOCONNECT_URI_RESULT)) {
 
     // Setup /_ac/result
     elm->setMold(FPSTR("{{RESULT}}"));
     elm->addToken(FPSTR("RESULT"), std::bind(&AutoConnectCore<T>::_invokeResult, this, std::placeholders::_1));
   }
-  else if (uri == String(AUTOCONNECT_URI_SUCCESS))
-  {
+  else if (uri == String(AUTOCONNECT_URI_SUCCESS)) {
 
     // Setup /_ac/success
     elm->setMold(FPSTR(_PAGE_SUCCESS));
@@ -1706,8 +1659,7 @@ PageElement *AutoConnectCore<T>::_setupPage(String &uri)
     elm->addToken(FPSTR("CHANNEL"), std::bind(&AutoConnectCore<T>::_token_CHANNEL, this, std::placeholders::_1));
     elm->addToken(FPSTR("DBM"), std::bind(&AutoConnectCore<T>::_token_DBM, this, std::placeholders::_1));
   }
-  else if (uri == String(AUTOCONNECT_URI_FAIL))
-  {
+  else if (uri == String(AUTOCONNECT_URI_FAIL)) {
 
     // Setup /_ac/fail
     _menuTitle = FPSTR(AUTOCONNECT_MENUTEXT_FAILED);
@@ -1721,16 +1673,14 @@ PageElement *AutoConnectCore<T>::_setupPage(String &uri)
     elm->addToken(FPSTR("MENU_POST"), std::bind(&AutoConnectCore<T>::_token_MENU_POST, this, std::placeholders::_1));
     elm->addToken(FPSTR("STATION_STATUS"), std::bind(&AutoConnectCore<T>::_token_STATION_STATUS, this, std::placeholders::_1));
   }
-  else
-  {
+  else {
     delete elm;
     elm = nullptr;
   }
 
   // Regiter authentication
   // Determine the necessity of authentication from the AutoConnectConfig settings
-  if (elm)
-  {
+  if (elm) {
     bool auth = (_apConfig.auth != AC_AUTH_NONE) &&
                 (_apConfig.authScope & AC_AUTHSCOPE_AC) &&
                 reqAuth;
@@ -1747,11 +1697,10 @@ PageElement *AutoConnectCore<T>::_setupPage(String &uri)
  *  It determines to admit authentication in the captive portal state
  *  when the AP_AUTHSCOPE_WITHCP is enabled.
  *  @param allow  Indication of whether to authenticate with the page.
- */
-template <typename T>
-void AutoConnectCore<T>::_authentication(bool allow)
-{
-  HTTPAuthMethod method = _apConfig.auth == AC_AUTH_BASIC ? HTTPAuthMethod::BASIC_AUTH : HTTPAuthMethod::DIGEST_AUTH;
+ */ 
+template<typename T>
+void AutoConnectCore<T>::_authentication(bool allow) {
+  HTTPAuthMethod  method = _apConfig.auth == AC_AUTH_BASIC ? HTTPAuthMethod::BASIC_AUTH : HTTPAuthMethod::DIGEST_AUTH;
   _authentication(allow, method);
 }
 
@@ -1762,24 +1711,22 @@ void AutoConnectCore<T>::_authentication(bool allow)
  *  It determines to admit authentication in the captive portal state
  *  when the AP_AUTHSCOPE_WITHCP is enabled.
  *  @param allow  Indication of whether to authenticate with the page.
- */
-template <typename T>
-void AutoConnectCore<T>::_authentication(bool allow, const HTTPAuthMethod method)
-{
-  const char *user = nullptr;
-  const char *password = nullptr;
-  String fails;
+ */ 
+template<typename T>
+void AutoConnectCore<T>::_authentication(bool allow, const HTTPAuthMethod method) {
+  const char* user = nullptr;
+  const char* password = nullptr;
+  String  fails;
 
   // Enable authentication by setting of AC_AUTHSCOPE_DISCONNECTED even if WiFi is not connected.
-  String accUrl = _webServer->hostHeader();
+  String  accUrl = _webServer->hostHeader();
 
   if (WiFi.status() != WL_CONNECTED)
     allow = _apConfig.authScope & AC_AUTHSCOPE_WITHCP;
   else if ((WiFi.getMode() & WIFI_AP) && ((accUrl == WiFi.softAPIP().toString()) || accUrl.endsWith(F(".local"))))
     allow = _apConfig.authScope & AC_AUTHSCOPE_WITHCP;
 
-  if (allow)
-  {
+  if (allow) {
     // Regiter authentication method
     user = _apConfig.username.length() ? _apConfig.username.c_str() : _apConfig.apid.c_str();
     password = _apConfig.password.length() ? _apConfig.password.c_str() : _apConfig.psk.c_str();


### PR DESCRIPTION
Hello Hieromon,
here is a small contribution, I added the system uptime to the STAT page.
It should work on ESP32 and ESP8266 (untested). 
On ESP32 is based on esp_timer_get_time() and on ESP8266 on millis().

Please note: the current implementation is not reliable on ESP8266 since the mills() function is returning an int32_t and it will overflow in less than 50 days. With some more effort, it would be easily possible to keep track of millis() reset, to show the correct uptime after 50 days, but this is too a bit too much for my cpp capabilities :)
On ESP32 It will overflow after 292,000 years.

Thank you
Andrea