### PR TITLE
Add support for ESP32 Core v3.x and ArduinoJson 7 compilation fix

### DIFF
--- a/src/AutoConnectCoreImpl.hpp
+++ b/src/AutoConnectCoreImpl.hpp
@@ -246,7 +246,11 @@ bool AutoConnectCore<T>::begin(const char* ssid, const char* passphrase, unsigne
     if (_apConfig.autoRise) {
 
       // Change WiFi working mode, Enable AP with STA
-      WiFi.setAutoConnect(false);
+#if defined(ARDUINO_ARCH_ESP32) && ((ESP_IDF_VERSION_MAJOR > 3) || ((ESP_IDF_VERSION_MAJOR == 3) && (ESP_IDF_VERSION_MINOR >= 1)))
+      WiFi.setAutoReconnect(false);
+#else
+      WiFi.setAutoConnect(false); // Deprecated in ESP32 from ESP-IDF v3.1
+#endif
       disconnect(false, true);
 
       // Activate the AP mode with configured softAP and start the access point.
@@ -559,8 +563,13 @@ void AutoConnectCore<T>::handleRequest(void) {
     if (_apConfig.retainPortal && _apConfig.autoRise) {
       // Cancel AutoReconnect to ensure detection for queries to penetrate
       // to the internet from a client.
-      if (WiFi.getAutoConnect())
+#if defined(ARDUINO_ARCH_ESP32) && ((ESP_IDF_VERSION_MAJOR > 3) || ((ESP_IDF_VERSION_MAJOR == 3) && (ESP_IDF_VERSION_MINOR >= 1)))
+      if (WiFi.getAutoReconnect())
         WiFi.setAutoReconnect(false);
+#else
+      if (WiFi.getAutoConnect()) // Deprecated in ESP32 from ESP-IDF v3.1
+        WiFi.setAutoReconnect(false);
+#endif
 
       // Restart the responder for the captive portal detection.
       if (!(WiFi.getMode() & WIFI_AP)) {

--- a/src/AutoConnectCoreImpl.hpp
+++ b/src/AutoConnectCoreImpl.hpp
@@ -31,10 +31,10 @@
 
 // An actual reset function dependent on the architecture
 #if defined(ARDUINO_ARCH_ESP8266)
-#define SOFT_RESET()  ESP.reset()
+#define SOFT_RESET_ESP()  ESP.reset()
 #define SET_HOSTNAME(x) do { WiFi.hostname(x); } while(0)
 #elif defined(ARDUINO_ARCH_ESP32)
-#define SOFT_RESET()  ESP.restart()
+#define SOFT_RESET_ESP()  ESP.restart()
 #define SET_HOSTNAME(x) do { WiFi.setHostname(x); } while(0)
 #endif
 
@@ -728,7 +728,7 @@ void AutoConnectCore<T>::handleRequest(void) {
     _stopPortal();
     AC_DBG("Reset\n");
     delay(1000);
-    SOFT_RESET();
+    SOFT_RESET_ESP();
     delay(1000);
   }
 
@@ -756,7 +756,7 @@ void AutoConnectCore<T>::handleRequest(void) {
 
       if (_apConfig.autoReset) {
         delay(1000);
-        SOFT_RESET();
+        SOFT_RESET_ESP();
         delay(1000);
       }
     }

--- a/src/AutoConnectJsonDefs.h
+++ b/src/AutoConnectJsonDefs.h
@@ -58,6 +58,17 @@ struct SpiRamAllocatorST {
   void  deallocate(void* pointer) {
     heap_caps_free(pointer);
   }
+  void* reallocate(void *pointer, size_t new_size) {
+    uint32_t caps;
+    if (psramFound())
+      caps = MALLOC_CAP_SPIRAM;
+    else
+    {
+      caps = MALLOC_CAP_8BIT;
+      AC_DBG("PSRAM not found, JSON buffer allocates to the heap.\n");
+    }
+    return heap_caps_realloc(pointer, new_size, caps);
+  }
 };
 #define AUTOCONNECT_JSONBUFFER_PRIMITIVE_SIZE AUTOCONNECT_JSONPSRAM_SIZE
 using ArduinoJsonBuffer = BasicJsonDocument<SpiRamAllocatorST>;

--- a/src/AutoConnectPageImpl.hpp
+++ b/src/AutoConnectPageImpl.hpp
@@ -16,7 +16,13 @@ extern "C" {
 #include <user_interface.h>
 }
 #elif defined(ARDUINO_ARCH_ESP32)
+#ifdef ESP_IDF_VERSION_MAJOR
+#if ESP_IDF_VERSION_MAJOR >= 5
+#include <esp_flash.h>
+#else
 #include <esp_spi_flash.h>
+#endif
+#endif
 #include <WiFi.h>
 #define ENC_TYPE_NONE WIFI_AUTH_OPEN
 #endif
@@ -998,7 +1004,13 @@ uint32_t AutoConnectCore<T>::_getFlashChipRealSize() {
 #if defined(ARDUINO_ARCH_ESP8266)
   return ESP.getFlashChipRealSize();
 #elif defined(ARDUINO_ARCH_ESP32)
+#if ESP_IDF_VERSION_MAJOR >= 5
+  uint32_t size_flash_chip;
+  esp_flash_get_size(NULL, &size_flash_chip);
+  return size_flash_chip;
+#else
   return (uint32_t)spi_flash_get_chip_size();
+#endif
 #endif
 }
 


### PR DESCRIPTION
The ESP32 Arduino Core 3.x based on ESP-IDF 5.x breaks compatibility with the AutoConnect library. These fixes make it possible for the library to compile with Core 3.x versions and it seems to be working properly (tested on ESP32-S3).

- WiFi.getAutoConnect() and WiFi.setAutoConnect() have been deprecated by long time in ESP32 Core 2.x (ever since ESP-IDF 3.1 these functions do nothing, they just return false) and removed completely in Core 3.x. **Use WiFi.getAutoReconnect() and WiFi.setAutoReconnect() if on ESP-IDF 3.1 or later on ESP32 platform.**
- spi_flash_get_chip_size() has been deprecated and removed from ESP-IDF 5.x and later, which ESP32 Core 3.x is based on. **Use esp_flash_get_size() instead if on ESP-IDF 5.x or later.**

Moreover, following change to fix compilation error when using ArduinoJson 7 on ESP32. This makes compilation possible and adds initial support but, ideally, it still needs refactoring to fix various warnings due to the use of deprecated functions:

- Add function ***reallocate()** in SpiRamAllocatorST

Last change is just on a definition used only in AutoConnectCoreImpl.hpp. It doesn't do anything, but I changed it because it used to conflict with another library I used with AutoConnect:

- Renamed SOFT_RESET() to **SOFT_RESET_ESP()**